### PR TITLE
Load ttl files in subdirectories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
@@ -10,6 +11,7 @@
 		<neo4j.version>3.3.2</neo4j.version>
 		<sesame.version>2.2.4</sesame.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<apache-common.version>3.7</apache-common.version>
 	</properties>
 
 	<dependencies>
@@ -20,10 +22,10 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-		    <groupId>org.neo4j</groupId>
-		    <artifactId>server-api</artifactId>
-		    <version>${neo4j.version}</version>
-            <scope>provided</scope>
+			<groupId>org.neo4j</groupId>
+			<artifactId>server-api</artifactId>
+			<version>${neo4j.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
@@ -109,6 +111,11 @@
 			<version>1.5.0-beta03</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>${apache-common.version}</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -130,7 +137,8 @@
 						</goals>
 						<configuration>
 							<transformers>
-								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
 							</transformers>
 						</configuration>
 					</execution>

--- a/src/main/java/semantics/RDFImport.java
+++ b/src/main/java/semantics/RDFImport.java
@@ -1,5 +1,26 @@
 package semantics;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.FilenameUtils;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.rio.RDFParseException;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.Rio;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
@@ -10,208 +31,289 @@ import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Mode;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
-import org.eclipse.rdf4j.rio.*;
-import semantics.result.GraphResult;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.nio.charset.Charset;
-import java.util.*;
-import java.util.stream.Stream;
+import semantics.result.GraphResult;
 
 /**
  * Created by jbarrasa on 21/03/2016.
  * <p>
- * RDF importer based on:
- * 1. DatatypeProperties become node attributes
- * 2. rdf:type relationships are transformed into labels on the subject node
- * 3. rdf:type relationships generate :Class nodes on the object
+ * RDF importer based on: 1. DatatypeProperties become node attributes 2.
+ * rdf:type relationships are transformed into labels on the subject node 3.
+ * rdf:type relationships generate :Class nodes on the object
  */
 public class RDFImport {
-    private static final boolean DEFAULT_SHORTEN_URLS = true;
-    private static final boolean DEFAULT_TYPES_TO_LABELS = true;
-    private static final long DEFAULT_COMMIT_SIZE = 25000;
-    private static final long DEFAULT_NODE_CACHE_SIZE = 10000;
-    public static final String PREFIX_SEPARATOR = "__";
+	private static final boolean DEFAULT_SHORTEN_URLS = true;
+	private static final boolean DEFAULT_TYPES_TO_LABELS = true;
+	private static final long DEFAULT_COMMIT_SIZE = 25000;
+	private static final long DEFAULT_NODE_CACHE_SIZE = 10000;
+	public static final String PREFIX_SEPARATOR = "__";
 
-    @Context
-    public GraphDatabaseService db;
-    @Context
-    public Log log;
+	@Context
+	public GraphDatabaseService db;
+	@Context
+	public Log log;
 
-    public static RDFFormat[] availableParsers = new RDFFormat[]{RDFFormat.RDFXML, RDFFormat.JSONLD, RDFFormat.TURTLE,
-            RDFFormat.NTRIPLES, RDFFormat.TRIG};
+	public static RDFFormat[] availableParsers = new RDFFormat[] { RDFFormat.RDFXML, RDFFormat.JSONLD, RDFFormat.TURTLE,
+			RDFFormat.NTRIPLES, RDFFormat.TRIG };
 
+	@Procedure(mode = Mode.WRITE)
+	public Stream<ImportResults> importRDF(@Name("url") String url, 
+			@Name("format") String format,
+			@Name("props") Map<String, Object> props) {
 
+		final boolean shortenUrls = (props.containsKey("shortenUrls") ? (boolean) props.get("shortenUrls") : DEFAULT_SHORTEN_URLS);
+		final boolean typesToLabels = (props.containsKey("typesToLabels") ? (boolean) props.get("typesToLabels") : DEFAULT_TYPES_TO_LABELS);
+		final long commitSize = (props.containsKey("commitSize") ? (long) props.get("commitSize") : DEFAULT_COMMIT_SIZE);
+		final long nodeCacheSize = (props.containsKey("nodeCacheSize") ? (long) props.get("nodeCacheSize") : DEFAULT_NODE_CACHE_SIZE);
+		final String languageFilter = (props.containsKey("languageFilter") ? (String) props.get("languageFilter") : null);
 
-    @Procedure(mode = Mode.WRITE)
-    public Stream<ImportResults> importRDF(@Name("url") String url, @Name("format") String format,
-                                           @Name("props") Map<String, Object> props) {
+		ImportResults importResults = new ImportResults();
+		
+		try {
+			List<String> listOfUrls = getTTLUrls(url);
+			for (String oneUrl : listOfUrls) {
 
-        final boolean shortenUrls = (props.containsKey("shortenUrls")?(boolean)props.get("shortenUrls"):DEFAULT_SHORTEN_URLS);
-        final boolean typesToLabels = (props.containsKey("typesToLabels")?(boolean)props.get("typesToLabels"):DEFAULT_TYPES_TO_LABELS);
-        final long commitSize = (props.containsKey("commitSize")?(long)props.get("commitSize"):DEFAULT_COMMIT_SIZE);
-        final long nodeCacheSize = (props.containsKey("nodeCacheSize")?(long)props.get("nodeCacheSize"):DEFAULT_NODE_CACHE_SIZE);
-        final String languageFilter = (props.containsKey("languageFilter")?(String)props.get("languageFilter"):null);
+				DirectStatementLoader statementLoader = new DirectStatementLoader(db,
+						(commitSize > 0 ? commitSize : 5000), nodeCacheSize, shortenUrls, typesToLabels, languageFilter,
+						log);
 
-        ImportResults importResults = new ImportResults();
-        URLConnection urlConn;
-        DirectStatementLoader statementLoader = new DirectStatementLoader(db, (commitSize > 0 ? commitSize : 5000),
-                nodeCacheSize, shortenUrls, typesToLabels, languageFilter, log);
-        try {
-            checkIndexesExist();
-            urlConn = new URL(url).openConnection();
-            if (props.containsKey("headerParams")) {
-                ((Map<String, String>) props.get("headerParams")).forEach( (k,v) -> urlConn.setRequestProperty(k,v));
-            }
-            InputStream inputStream = urlConn.getInputStream();
-            RDFParser rdfParser = Rio.createParser(getFormat(format));
-            rdfParser.setRDFHandler(statementLoader);
-            rdfParser.parse(inputStream, url);
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        } catch (IOException | RDFHandlerException | QueryExecutionException | RDFParseException | RDFImportPreRequisitesNotMet e) {
-            importResults.setTerminationKO(e.getMessage());
-            e.printStackTrace();
-        } finally {
-            importResults.setTriplesLoaded(statementLoader.getIngestedTriples());
-            importResults.setNamespaces(statementLoader.getNamespaces());
-        }
-        return Stream.of(importResults);
-    }
+				ImportResults iResults = importRDFProcessor(oneUrl, format, props, statementLoader);
+				importResults.setNamespaces(iResults.namespaces);
+				importResults.setTriplesLoaded(iResults.triplesLoaded);
+				importResults.setTerminationKO(iResults.extraInfo);
+			}
+		} catch (MalformedURLException ex) {
+			ex.printStackTrace();
+		}
+		
+		return Stream.of(importResults);
+		
+	}
 
-    @Procedure(mode = Mode.READ)
-    public Stream<GraphResult> previewRDF(@Name("url") String url, @Name("format") String format,
-                                          @Name("props") Map<String, Object> props) {
+	private ImportResults importRDFProcessor(String url, String format, Map<String, Object> props, DirectStatementLoader statementLoader) {
+		
+		ImportResults importResults = new ImportResults();
+		
+		URLConnection urlConn;
+		
+		try {
+			checkIndexesExist();
 
-        final boolean shortenUrls = (props.containsKey("shortenUrls")?(boolean)props.get("shortenUrls"):DEFAULT_SHORTEN_URLS);
-        final boolean typesToLabels = (props.containsKey("typesToLabels")?(boolean)props.get("typesToLabels"):DEFAULT_TYPES_TO_LABELS);
-        final String languageFilter = (props.containsKey("languageFilter")?(String)props.get("languageFilter"):null);
+			urlConn = new URL(url).openConnection();
+			if (props.containsKey("headerParams")) {
+				((Map<String, String>) props.get("headerParams")).forEach((k, v) -> urlConn.setRequestProperty(k, v));
+			}
+			InputStream inputStream = urlConn.getInputStream();
+			RDFParser rdfParser = Rio.createParser(getFormat(format));
+			rdfParser.setRDFHandler(statementLoader);
+			rdfParser.parse(inputStream, url);
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		} catch (IOException | RDFHandlerException | QueryExecutionException | RDFParseException
+				| RDFImportPreRequisitesNotMet e) {
+			importResults.setTerminationKO(e.getMessage());
+			e.printStackTrace();
+		} finally {
+			importResults.setTriplesLoaded(statementLoader.getIngestedTriples());
+			importResults.setNamespaces(statementLoader.getNamespaces());
+		}
+		
+		return importResults;
+	}
 
-        URLConnection urlConn;
-        Map<String,Node> virtualNodes = new HashMap<>();
-        List<Relationship> virtualRels = new ArrayList<>();
+	/**
+	 * Accepts a url of the form: http:// or file://
+	 * If url protocol is file:// and is directory, collects all ttl files in subfolders
+	 * @param url
+	 * @return a list of one or more urls
+	 * @throws MalformedURLException
+	 */
+	private List<String> getTTLUrls(String url) throws MalformedURLException {
+		
+		List<String> listOfUrls = new ArrayList<String>();
 
-        StatementPreviewer statementViewer = new StatementPreviewer(db, shortenUrls, typesToLabels, virtualNodes, virtualRels, languageFilter, log);
-        try {
-            urlConn = new URL(url).openConnection();
-            if (props.containsKey("headerParams")) {
-                ((Map<String, String>) props.get("headerParams")).forEach( (k,v) -> urlConn.setRequestProperty(k,v));
-            }
-            InputStream inputStream = urlConn.getInputStream();
-            RDFFormat rdfFormat = getFormat(format);
-            log.info("Data set to be parsed as " + rdfFormat);
-            RDFParser rdfParser = Rio.createParser(rdfFormat);
-            rdfParser.setRDFHandler(statementViewer);
-            rdfParser.parse(inputStream, "http://neo4j.com/base/");
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        } catch (IOException | RDFHandlerException | QueryExecutionException | RDFParseException | RDFImportPreRequisitesNotMet e) {
-            e.printStackTrace();
-        }
+		URL lURL = new URL(url);
+		
+		//Handle only file protocol else ignore http protocol
+		if ("file".equalsIgnoreCase(lURL.getProtocol())) {
+			String file = lURL.getFile();
+			//Handle file = directory
+			if (new File(file).isDirectory()) {
+				listOfUrls = loadTTLFiles(file);
+			} else {
+				listOfUrls.add(url);
+			}
+		} else {
+			listOfUrls.add(url);
+		}
+		
+		return listOfUrls;
+	}
 
-        GraphResult graphResult = new GraphResult(new ArrayList<>(virtualNodes.values()), virtualRels);
-        return Stream.of(graphResult);
+	/**
+	 * Recursively load all ttl files it finds in subdirectories
+	 * @param directoryName
+	 * @return list of fullpath of ttl files
+	 */
+	private static List<String> loadTTLFiles(String directoryName) {
 
+		File directory = new File(directoryName);
 
-    }
+		List<String> lFiles = new ArrayList<String>();
 
-    @Procedure(mode = Mode.READ)
-    public Stream<GraphResult> previewRDFSnippet(@Name("rdf") String rdfFragment, @Name("format") String format,
-                                                 @Name("props") Map<String, Object> props) {
+		// Get all the ttl files from the sub-directory
+		File[] fList = directory.listFiles();
+		for (File file : fList) {
+			if (file.isFile()) {
 
-        final boolean shortenUrls = (props.containsKey("shortenUrls")?(boolean)props.get("shortenUrls"):DEFAULT_SHORTEN_URLS);
-        final boolean typesToLabels = (props.containsKey("typesToLabels")?(boolean)props.get("typesToLabels"):DEFAULT_TYPES_TO_LABELS);
-        final String languageFilter = (props.containsKey("languageFilter")?(String)props.get("languageFilter"):null);
+				//Skip files which are NOT ttl
+				if (!FilenameUtils.getExtension(file.getName()).equalsIgnoreCase("ttl")) {
+					continue;
+				}
+				
+				lFiles.add("file:" + file.toPath().toString());
+				
+			} else if (file.isDirectory()) {
+				lFiles.addAll(loadTTLFiles(file.getAbsolutePath()));
+			}
+		}
+		return lFiles;
+	}
 
-        Map<String,Node> virtualNodes = new HashMap<>();
-        List<Relationship> virtualRels = new ArrayList<>();
+	@Procedure(mode = Mode.READ)
+	public Stream<GraphResult> previewRDF(@Name("url") String url, @Name("format") String format,
+			@Name("props") Map<String, Object> props) {
 
-        StatementPreviewer statementViewer = new StatementPreviewer(db, shortenUrls, typesToLabels, virtualNodes, virtualRels, languageFilter, log);
-        try {
-            InputStream inputStream = new ByteArrayInputStream( rdfFragment.getBytes(Charset.defaultCharset()) ); //rdfFragment.openStream();
-            RDFFormat rdfFormat = getFormat(format);
-            log.info("Data set to be parsed as " + rdfFormat);
-            RDFParser rdfParser = Rio.createParser(rdfFormat);
-            rdfParser.setRDFHandler(statementViewer);
-            rdfParser.parse(inputStream, "http://neo4j.com/base/");
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        } catch (IOException | RDFHandlerException | QueryExecutionException | RDFParseException | RDFImportPreRequisitesNotMet e) {
-            e.printStackTrace();
-        }
+		final boolean shortenUrls = (props.containsKey("shortenUrls") ? (boolean) props.get("shortenUrls")
+				: DEFAULT_SHORTEN_URLS);
+		final boolean typesToLabels = (props.containsKey("typesToLabels") ? (boolean) props.get("typesToLabels")
+				: DEFAULT_TYPES_TO_LABELS);
+		final String languageFilter = (props.containsKey("languageFilter") ? (String) props.get("languageFilter")
+				: null);
 
-        GraphResult graphResult = new GraphResult(new ArrayList<>(virtualNodes.values()), virtualRels);
-        return Stream.of(graphResult);
+		URLConnection urlConn;
+		Map<String, Node> virtualNodes = new HashMap<>();
+		List<Relationship> virtualRels = new ArrayList<>();
 
+		StatementPreviewer statementViewer = new StatementPreviewer(db, shortenUrls, typesToLabels, virtualNodes,
+				virtualRels, languageFilter, log);
+		try {
+			urlConn = new URL(url).openConnection();
+			if (props.containsKey("headerParams")) {
+				((Map<String, String>) props.get("headerParams")).forEach((k, v) -> urlConn.setRequestProperty(k, v));
+			}
+			InputStream inputStream = urlConn.getInputStream();
+			RDFFormat rdfFormat = getFormat(format);
+			log.info("Data set to be parsed as " + rdfFormat);
+			RDFParser rdfParser = Rio.createParser(rdfFormat);
+			rdfParser.setRDFHandler(statementViewer);
+			rdfParser.parse(inputStream, "http://neo4j.com/base/");
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		} catch (IOException | RDFHandlerException | QueryExecutionException | RDFParseException
+				| RDFImportPreRequisitesNotMet e) {
+			e.printStackTrace();
+		}
 
-    }
-    private void checkIndexesExist() throws RDFImportPreRequisitesNotMet {
-        Iterable<IndexDefinition> indexes = db.schema().getIndexes();
-        if(missing(indexes.iterator(),"Resource")){
-            throw new RDFImportPreRequisitesNotMet("The required index on :Resource(uri) could not be found");
-        }
-    }
+		GraphResult graphResult = new GraphResult(new ArrayList<>(virtualNodes.values()), virtualRels);
+		return Stream.of(graphResult);
 
-    private boolean missing(Iterator<IndexDefinition> iterator, String indexLabel) {
-        while (iterator.hasNext()){
-            IndexDefinition indexDef = iterator.next();
-            if(indexDef.getLabel().name().equals(indexLabel) &&
-                    indexDef.getPropertyKeys().iterator().next().equals("uri")) {
-                return false;
-            }
-        }
-        return true;
-    }
+	}
 
-    private RDFFormat getFormat(String format) throws RDFImportPreRequisitesNotMet {
-        if (format != null) {
-            for (RDFFormat parser : availableParsers) {
-                if (parser.getName().equals(format))
-                    return parser;
-            }
-        }
-        throw new RDFImportPreRequisitesNotMet("Unrecognized serialization format: " + format);
-    }
+	@Procedure(mode = Mode.READ)
+	public Stream<GraphResult> previewRDFSnippet(@Name("rdf") String rdfFragment, @Name("format") String format,
+			@Name("props") Map<String, Object> props) {
 
+		final boolean shortenUrls = (props.containsKey("shortenUrls") ? (boolean) props.get("shortenUrls")
+				: DEFAULT_SHORTEN_URLS);
+		final boolean typesToLabels = (props.containsKey("typesToLabels") ? (boolean) props.get("typesToLabels")
+				: DEFAULT_TYPES_TO_LABELS);
+		final String languageFilter = (props.containsKey("languageFilter") ? (String) props.get("languageFilter")
+				: null);
 
+		Map<String, Node> virtualNodes = new HashMap<>();
+		List<Relationship> virtualRels = new ArrayList<>();
 
+		StatementPreviewer statementViewer = new StatementPreviewer(db, shortenUrls, typesToLabels, virtualNodes,
+				virtualRels, languageFilter, log);
+		try {
+			InputStream inputStream = new ByteArrayInputStream(rdfFragment.getBytes(Charset.defaultCharset())); // rdfFragment.openStream();
+			RDFFormat rdfFormat = getFormat(format);
+			log.info("Data set to be parsed as " + rdfFormat);
+			RDFParser rdfParser = Rio.createParser(rdfFormat);
+			rdfParser.setRDFHandler(statementViewer);
+			rdfParser.parse(inputStream, "http://neo4j.com/base/");
+		} catch (MalformedURLException e) {
+			e.printStackTrace();
+		} catch (IOException | RDFHandlerException | QueryExecutionException | RDFParseException
+				| RDFImportPreRequisitesNotMet e) {
+			e.printStackTrace();
+		}
 
-    public static class ImportResults {
-        public String terminationStatus = "OK";
-        public long triplesLoaded = 0;
-        public Map<String,String> namespaces;
-        public String extraInfo = "";
+		GraphResult graphResult = new GraphResult(new ArrayList<>(virtualNodes.values()), virtualRels);
+		return Stream.of(graphResult);
 
-        public void setTriplesLoaded(long triplesLoaded) {
-            this.triplesLoaded = triplesLoaded;
-        }
+	}
 
-        public void setNamespaces(Map<String, String> namespaces) {
-            this.namespaces = namespaces;
-        }
+	private void checkIndexesExist() throws RDFImportPreRequisitesNotMet {
+		Iterable<IndexDefinition> indexes = db.schema().getIndexes();
+		if (missing(indexes.iterator(), "Resource")) {
+			throw new RDFImportPreRequisitesNotMet("The required index on :Resource(uri) could not be found");
+		}
+	}
 
-        public void setTerminationKO(String message) {
-            this.terminationStatus = "KO";
-            this.extraInfo = message;
-        }
+	private boolean missing(Iterator<IndexDefinition> iterator, String indexLabel) {
+		while (iterator.hasNext()) {
+			IndexDefinition indexDef = iterator.next();
+			if (indexDef.getLabel().name().equals(indexLabel)
+					&& indexDef.getPropertyKeys().iterator().next().equals("uri")) {
+				return false;
+			}
+		}
+		return true;
+	}
 
-    }
+	private RDFFormat getFormat(String format) throws RDFImportPreRequisitesNotMet {
+		if (format != null) {
+			for (RDFFormat parser : availableParsers) {
+				if (parser.getName().equals(format))
+					return parser;
+			}
+		}
+		throw new RDFImportPreRequisitesNotMet("Unrecognized serialization format: " + format);
+	}
 
-    private class RDFImportPreRequisitesNotMet extends Exception {
-        String message;
+	public static class ImportResults {
+		public String terminationStatus = "OK";
+		public long triplesLoaded = 0;
+		public Map<String, String> namespaces = new HashMap<String, String>();
+		public String extraInfo = "";
 
-        public RDFImportPreRequisitesNotMet(String s) {
-            message = s;
-        }
+		public void setTriplesLoaded(long triplesLoaded) {
+			this.triplesLoaded += triplesLoaded;
+		}
 
-        @Override
-        public String getMessage() {
-            return message;
-        }
-    }
+		public void setNamespaces(Map<String, String> namespaces) {
+			this.namespaces.putAll(namespaces);
+		}
+
+		public void setTerminationKO(String message) {
+			this.terminationStatus = "KO";
+			this.extraInfo = message;
+		}
+
+	}
+
+	private class RDFImportPreRequisitesNotMet extends Exception {
+		String message;
+
+		public RDFImportPreRequisitesNotMet(String s) {
+			message = s;
+		}
+
+		@Override
+		public String getMessage() {
+			return message;
+		}
+	}
 }

--- a/src/test/resources/rootTTLs/sub1/testTurtle-sub1.ttl
+++ b/src/test/resources/rootTTLs/sub1/testTurtle-sub1.ttl
@@ -1,0 +1,14 @@
+@prefix :      <http://www.example.com/ontology/1.0.0#> .
+@prefix common: <http://www.example.com/ontology/1.0.0/common#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix project: <http://www.example.com/ontology/1.0.0/project#> .
+
+project:DISTANCEVALUE-A181451
+        a       :DISTANCEVALUE ;
+        :units  common:MEASUREMENTUNIT-T1510615421641 ;
+        :value  0.55 .
+
+common:MEASUREMENTUNIT-T1510615421641
+        a               :MEASUREMENTUNIT ;
+        :name           "metres" .

--- a/src/test/resources/rootTTLs/sub2/testTurtle-sub2.ttl
+++ b/src/test/resources/rootTTLs/sub2/testTurtle-sub2.ttl
@@ -1,0 +1,14 @@
+@prefix :      <http://www.example.com/ontology/1.0.0#> .
+@prefix common: <http://www.example.com/ontology/1.0.0/common#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix project: <http://www.example.com/ontology/1.0.0/project#> .
+
+project:DISTANCEVALUE-A181452
+        a       :DISTANCEVALUE ;
+        :units  common:MEASUREMENTUNIT-T1510615421642 ;
+        :value  0.55 .
+
+common:MEASUREMENTUNIT-T1510615421642
+        a               :MEASUREMENTUNIT ;
+        :name           "metres" .

--- a/src/test/resources/rootTTLs/sub3/testTurtle-sub3.ttl
+++ b/src/test/resources/rootTTLs/sub3/testTurtle-sub3.ttl
@@ -1,0 +1,14 @@
+@prefix :      <http://www.example.com/ontology/1.0.0#> .
+@prefix common: <http://www.example.com/ontology/1.0.0/common#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix project: <http://www.example.com/ontology/1.0.0/project#> .
+
+project:DISTANCEVALUE-A181453
+        a       :DISTANCEVALUE ;
+        :units  common:MEASUREMENTUNIT-T1510615421643 ;
+        :value  0.55 .
+
+common:MEASUREMENTUNIT-T1510615421643
+        a               :MEASUREMENTUNIT ;
+        :name           "metres" .


### PR DESCRIPTION
This branch allows processing of multiple .TTL files in multiple subfolders. You just have to pass the root folder and it will loop through all subfolders and load all .ttl files it finds. e.g. In the Neo4j browser you type:
**_CALL semantics.importRDF("file:/Users/dev/myttls","Turtle", {shortenUrls: true, typesToLabels: true, commitSize: 9000})_**. All .TTL files in the root folder **myttls** together with .TTL files in the subfolders of **myttls** will be processed.
Hope this helps someone out there (as it helped me).
shalom
Mosheh