### PR TITLE
Fix typo in _subPropertyOfRel map key and new date parser added

### DIFF
--- a/src/main/java/n10s/RDFToLPGStatementProcessor.java
+++ b/src/main/java/n10s/RDFToLPGStatementProcessor.java
@@ -2,6 +2,7 @@ package n10s;
 
 import n10s.graphconfig.GraphConfig;
 import n10s.graphconfig.RDFParserConfig;
+import n10s.utils.DateUtils;
 import n10s.utils.InvalidNamespacePrefixDefinitionInDB;
 import n10s.utils.NsPrefixMap;
 import org.eclipse.rdf4j.model.*;
@@ -14,10 +15,13 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.helpers.collection.Iterables;
 import org.neo4j.logging.Log;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.*;
+
+import javax.xml.bind.DatatypeConverter;
 
 import static n10s.graphconfig.GraphConfig.*;
 import static n10s.graphconfig.Params.CUSTOM_DATA_TYPE_SEPERATOR;
@@ -113,15 +117,15 @@ public abstract class RDFToLPGStatementProcessor extends ConfiguredStatementHand
       return object.booleanValue();
     } else if (datatype.equals(XMLSchema.DATETIME)) {
       try {
-        return LocalDateTime.parse(object.stringValue());
-      } catch (DateTimeParseException e) {
+        return DateUtils.parseDateTime(object.stringValue());
+      } catch (IllegalArgumentException e) {
         //if date cannot be parsed we return string value
         return object.stringValue();
       }
     } else if (datatype.equals(XMLSchema.DATE)) {
       try {
-        return LocalDate.parse(object.stringValue());
-      } catch (DateTimeParseException e) {
+        return DateUtils.parseDateTime(object.stringValue());
+      } catch (IllegalArgumentException e) {
         //if date cannot be parsed we return string value
         return object.stringValue();
       }
@@ -143,6 +147,8 @@ public abstract class RDFToLPGStatementProcessor extends ConfiguredStatementHand
     // default
     return object.stringValue();
   }
+  
+  
 
   protected String getValueWithDatatype(IRI datatype, String value) {
     StringBuilder result = new StringBuilder(value);

--- a/src/main/java/n10s/graphconfig/GraphConfig.java
+++ b/src/main/java/n10s/graphconfig/GraphConfig.java
@@ -313,7 +313,7 @@ public class GraphConfig {
     configAsMap.put("_subClassOfRel", this.subClassOfRelName);
     configAsMap.put("_dataTypePropertyLabel", this.dataTypePropertyLabelName);
     configAsMap.put("_objectPropertyLabel", this.objectPropertyLabelName);
-    configAsMap.put("_subPropertyOfRell", this.subPropertyOfRelName);
+    configAsMap.put("_subPropertyOfRel", this.subPropertyOfRelName);
     configAsMap.put("_domainRel", this.domainRelName);
     configAsMap.put("_rangeRel", this.rangeRelName);
 

--- a/src/main/java/n10s/utils/DateUtils.java
+++ b/src/main/java/n10s/utils/DateUtils.java
@@ -1,0 +1,54 @@
+package n10s.utils;
+
+import java.time.DateTimeException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Calendar;
+
+import javax.xml.bind.DatatypeConverter;
+
+public class DateUtils {
+	/**
+	 * Convert a String-formatted date into a LocalDateTime object by using
+	 * LocalDateTime.parse first, and DatatypeConverter.parseDateTime if the
+	 * first one fails.
+	 * @param stringDateTime
+	 *            The string-formatted date.
+	 * @return LocalDateTime object.
+	 * @throws IllegalArgumentException if the string is not parseable to a date.
+	 */
+	public static LocalDateTime parseDateTime(String stringDateTime) {
+		boolean dateParsed = false;
+		LocalDateTime localDateTime = null;
+		StringBuilder parserErrors = new StringBuilder("Error parsing ").append(stringDateTime).append(":\n");
+
+		/* Try date parsing with LocalDateTime.parse */
+		try {
+			localDateTime = LocalDateTime.parse(stringDateTime);
+			dateParsed = true;
+		} catch (DateTimeParseException e) {
+			dateParsed = false;
+			parserErrors.append(e.getMessage()).append("\n");
+		}
+
+		/* If date is not parsed */
+		if (!dateParsed) {
+			/* Try with DatatypeConverter.parseDateTime */
+			try {
+				Calendar calendar = DatatypeConverter.parseDateTime(stringDateTime);
+				localDateTime = LocalDateTime.ofInstant(calendar.toInstant(), calendar.getTimeZone().toZoneId());
+				dateParsed = true;
+			} catch (IllegalArgumentException | DateTimeException e) {
+				dateParsed = false;
+				parserErrors.append(e.getMessage()).append("\n");
+			}
+		}
+
+		/* If date is not parsed, throw exception */
+		if (!dateParsed) {
+			throw new IllegalArgumentException(parserErrors.toString());
+		} else {
+			return localDateTime;
+		}
+	}
+}


### PR DESCRIPTION
The name of sub property of relation cant be overridden because there is a typo when using the key in the map where these properties are stored, causing a mismatch (issue #182). I have written the correct key.

[EDIT] I recently added a function for parsing dates (issue #166). This function tries to parse the date as always but, if it fails, it tries another parser. At least, it works for me when parsing xsd:date with date time information.