### PR TITLE
Let's make unit tests run faster (4.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # neosemantics (n10s)
 ![n10s Logo](https://guides.neo4j.com/rdf/n10s.png) neosemantics is a plugin that enables the **use of RDF in Neo4j**. [RDF is a W3C standard model](https://www.w3.org/RDF/) for data interchange. Some key features of n10s are:
 
+
 * **Store RDF data in Neo4j** in a
 lossless manner (imported RDF can subsequently be exported without losing a single triple in the process).
 * On-demand **export property graph data** from Neo4j *as RDF*.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.neo4j</groupId>
   <artifactId>neosemantics</artifactId>
-  <version>4.4.0.2</version>
+  <version>5.1.0.0</version>
   <packaging>jar</packaging>
   <name>neosemantics (n10s)</name>
   <description>n10s is a plugin that enables the use of RDF in Neo4j</description>
@@ -34,8 +34,8 @@
   </developers>
 
   <properties>
-    <neo4j.version>4.4.11</neo4j.version>
-    <sesame.version>3.7.7</sesame.version>
+    <neo4j.version>5.1.0</neo4j.version>
+    <sesame.version>4.2.0</sesame.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/src/main/java/n10s/Util.java
+++ b/src/main/java/n10s/Util.java
@@ -126,7 +126,7 @@ public class Util {
       cypher.append("AND n.graphUri = $graphUri ");
       params.put("graphUri", graphUri);
     } else {
-      cypher.append("AND NOT EXISTS(n.graphUri) ");
+      cypher.append("AND n.graphUri is null ");
     }
     cypher.append("RETURN n");
     return cypher.toString();

--- a/src/main/java/n10s/endpoint/RDFEndpoint.java
+++ b/src/main/java/n10s/endpoint/RDFEndpoint.java
@@ -37,7 +37,6 @@ import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.logging.Log;
 
 /**
  * Created by jbarrasa on 08/09/2016.
@@ -69,10 +68,6 @@ public class RDFEndpoint {
   private static RDFFormat[] availableParsers = new RDFFormat[]{RDFFormat.RDFXML, RDFFormat.JSONLD,
       RDFFormat.TURTLE, RDFFormat.NTRIPLES, RDFFormat.TRIG, RDFFormat.NQUADS, RDFFormat.TURTLESTAR,
       RDFFormat.TRIGSTAR};
-
-  @Context
-  public Log log;
-
 
   @GET
   @Path("/ping")
@@ -321,26 +316,20 @@ public class RDFEndpoint {
   private RDFFormat getFormat(String mimetype, String formatParam) {
     // format request param overrides the one defined in the accept header param
     if (formatParam != null) {
-      log.debug("serialization from param in request: " + formatParam);
       for (RDFFormat parser : availableParsers) {
         if (parser.getName().contains(formatParam)) {
-          log.debug("parser to be used: " + parser.getDefaultMIMEType());
           return parser;
         }
       }
     } else {
       if (mimetype != null) {
-        log.debug("serialization from media type in request: " + mimetype);
         for (RDFFormat parser : availableParsers) {
           if (parser.getMIMETypes().contains(mimetype)) {
-            log.debug("parser to be used: " + parser.getDefaultMIMEType());
             return parser;
           }
         }
       }
     }
-
-    log.debug("Unrecognized or undefined serialization. Defaulting to Turtle serialization");
 
     return RDFFormat.TURTLE;
 

--- a/src/main/java/n10s/mapping/MappingUtils.java
+++ b/src/main/java/n10s/mapping/MappingUtils.java
@@ -65,7 +65,7 @@ public class MappingUtils {
         + "DETACH DELETE oldmd";
 
     String cleanOrphansIfAny = "MATCH (oldns:`_MapNs`)\n"
-        + " WHERE size((oldns)<-[:_IN]-())=0\n"
+        + " WHERE not (oldns)<-[:_IN]-() \n"
         + " DELETE oldns";
 
     String createNewMapping = "MERGE (newmns:`_MapNs` { _ns: $namespace, _prefix: $prefix }) \n"

--- a/src/main/java/n10s/mapping/MappingUtils.java
+++ b/src/main/java/n10s/mapping/MappingUtils.java
@@ -105,7 +105,7 @@ public class MappingUtils {
   public Stream<StringOutput> drop(@Name("graphElementName") String gElem)
       throws MappingDefinitionException {
     String cypher = "MATCH (mapns)<-[:_IN]-(elem:_MapDef { _key : $local }) DETACH DELETE elem "
-        + "RETURN count(elem) AS deletecount, size((mapns)<-[:_IN]-()) AS remaining, mapns ";
+        + "RETURN count(elem) AS deletecount, size([(mapns)<-[r:_IN]-() | r ]) AS remaining, mapns ";
     Map<String, Object> params = new HashMap<>();
     params.put("local", gElem);
     Result queryResult = tx.execute(cypher, params);

--- a/src/main/java/n10s/quadrdf/RDFQuadToLPGStatementProcessor.java
+++ b/src/main/java/n10s/quadrdf/RDFQuadToLPGStatementProcessor.java
@@ -106,7 +106,7 @@ abstract class RDFQuadToLPGStatementProcessor extends RDFToLPGStatementProcessor
       cypher.append("AND n.graphUri = $graphUri ");
       params.put("graphUri", graphUri);
     } else {
-      cypher.append("AND NOT EXISTS(n.graphUri) ");
+      cypher.append("AND n.graphUri is null ");
     }
     cypher.append("RETURN n");
     return cypher.toString();

--- a/src/main/java/n10s/rdf/export/LPGRDFToRDFProcesssor.java
+++ b/src/main/java/n10s/rdf/export/LPGRDFToRDFProcesssor.java
@@ -161,19 +161,19 @@ public class LPGRDFToRDFProcesssor extends ExportProcessor {
     params.put("uri", uri);
     if (graphId == null || graphId.equals("")) {
       queryWithContext = "MATCH (x:Resource {uri:$uri}) " +
-          "WHERE NOT EXISTS(x.graphUri)\n" +
+          "WHERE x.graphUri is null \n" +
           "OPTIONAL MATCH (x)-[r]-(val:Resource) " +
-          "WHERE exists(val.uri)\n" +
-          "AND NOT EXISTS(val.graphUri)\n" +
+          "WHERE val.uri is not null \n" +
+          "AND val.graphUri is null \n" +
           "RETURN x, r, val.uri AS value";
 
       queryNoContext = "MATCH (x:Resource {uri:$uri}) " +
-          "WHERE NOT EXISTS(x.graphUri)\n" +
+          "WHERE x.graphUri is null \n" +
           "RETURN x, null AS r, null AS value";
     } else {
       queryWithContext = "MATCH (x:Resource {uri:$uri, graphUri:$graphUri}) " +
           "OPTIONAL MATCH (x)-[r]-(val:Resource {graphUri:$graphUri}) " +
-          "WHERE exists(val.uri)\n" +
+          "WHERE val.uri is not null \n" +
           "RETURN x, r, val.uri AS value";
 
       queryNoContext = "MATCH (x:Resource {uri:$uri, graphUri:$graphUri}) " +
@@ -441,7 +441,7 @@ public class LPGRDFToRDFProcesssor extends ExportProcessor {
             result = tx.execute("MATCH (r:Resource) WHERE size(labels(r))>1 RETURN r");
           }  else {
             result = tx.execute(String
-                .format("MATCH (r:Resource) WHERE exists(r.`%s`) RETURN r\n"
+                .format("MATCH (r:Resource) WHERE r.`%s` is not null RETURN r\n"
                         + "UNION \n"
                         + "MATCH (:Resource)-[r:`%s`]->() RETURN r",
                     predicate, predicate));

--- a/src/main/java/n10s/rdf/export/LPGToRDFProcesssor.java
+++ b/src/main/java/n10s/rdf/export/LPGToRDFProcesssor.java
@@ -400,7 +400,7 @@ public class LPGToRDFProcesssor extends ExportProcessor {
             //CHECK IF predicate is <NONE>, in which case there's no point in running the query
             if (!predicate.equals(NOT_MATCHING_NS)) {
               result = tx.execute(String
-                      .format("MATCH (s) WHERE exists(s.`%s`) RETURN s, s.`%s` as o\n"
+                      .format("MATCH (s) WHERE s.`%s` is not null RETURN s, s.`%s` as o\n"
                                       + "UNION \n"
                                       + "MATCH (s)-[:`%s`]->(o) RETURN s, o",
                               predicate, predicate, predicate));

--- a/src/main/java/n10s/result/VirtualNode.java
+++ b/src/main/java/n10s/result/VirtualNode.java
@@ -11,11 +11,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import n10s.Util;
-import org.neo4j.graphdb.Direction;
-import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.*;
 import org.neo4j.internal.helpers.collection.FilteringIterable;
 import org.neo4j.internal.helpers.collection.Iterables;
 
@@ -62,6 +58,12 @@ public class VirtualNode implements Node {
   }
 
   @Override
+  public String getElementId()
+  {
+    return String.valueOf( id );
+  }
+
+  @Override
   public void delete() {
     for (Relationship rel : rels) {
       rel.delete();
@@ -69,8 +71,8 @@ public class VirtualNode implements Node {
   }
 
   @Override
-  public Iterable<Relationship> getRelationships() {
-    return rels;
+  public ResourceIterable<Relationship> getRelationships() {
+    return Iterables.asResourceIterable(rels);
   }
 
   @Override
@@ -79,8 +81,8 @@ public class VirtualNode implements Node {
   }
 
   @Override
-  public Iterable<Relationship> getRelationships(RelationshipType... relationshipTypes) {
-    return new FilteringIterable<>(rels, (r) -> isType(r, relationshipTypes));
+  public ResourceIterable<Relationship> getRelationships(RelationshipType... relationshipTypes) {
+    return Iterables.asResourceIterable(new FilteringIterable<>(rels, (r) -> isType(r, relationshipTypes)));
   }
 
   private boolean isType(Relationship r, RelationshipType... relationshipTypes) {
@@ -93,10 +95,10 @@ public class VirtualNode implements Node {
   }
 
   @Override
-  public Iterable<Relationship> getRelationships(Direction direction,
+  public ResourceIterable<Relationship> getRelationships(Direction direction,
       RelationshipType... relationshipTypes) {
-    return new FilteringIterable<>(rels,
-        (r) -> isType(r, relationshipTypes) && isDirection(r, direction));
+    return Iterables.asResourceIterable(new FilteringIterable<>(rels,
+        (r) -> isType(r, relationshipTypes) && isDirection(r, direction)));
   }
 
   private boolean isDirection(Relationship r, Direction direction) {
@@ -115,8 +117,8 @@ public class VirtualNode implements Node {
   }
 
   @Override
-  public Iterable<Relationship> getRelationships(Direction direction) {
-    return new FilteringIterable<>(rels, (r) -> isDirection(r, direction));
+  public ResourceIterable<Relationship> getRelationships(Direction direction) {
+    return Iterables.asResourceIterable(new FilteringIterable<>(rels, (r) -> isDirection(r, direction)));
   }
 
   @Override

--- a/src/main/java/n10s/result/VirtualRelationship.java
+++ b/src/main/java/n10s/result/VirtualRelationship.java
@@ -55,6 +55,12 @@ public class VirtualRelationship implements Relationship {
   }
 
   @Override
+  public String getElementId()
+  {
+    return String.valueOf( id );
+  }
+
+  @Override
   public void delete() {
     if (getStartNode() instanceof VirtualNode) {
       ((VirtualNode) getStartNode()).delete(this);

--- a/src/main/java/n10s/validation/SHACLValidator.java
+++ b/src/main/java/n10s/validation/SHACLValidator.java
@@ -1272,7 +1272,7 @@ public class SHACLValidator {
       case "GetRangeLiteralKind":
         query = getQuery((constraintType == CLASS_BASED_CONSTRAINT ? CYPHER_MATCH_WHERE : CYPHER_MATCH_ALL_WHERE),
                 tx, (constraintType == QUERY_BASED_CONSTRAINT ? customWhere + " and " : ""),
-                " exists(focus.`%s`) RETURN " + nodeIdFragment + nodeTypeFragment + shapeIdFragment
+                " focus.`%s` is not null RETURN " + nodeIdFragment + nodeTypeFragment + shapeIdFragment
                         + "'" + SHACL.NODE_KIND_CONSTRAINT_COMPONENT
                         + "' as propertyShape, null as offendingValue, "
                         + propertyNameFragment + severityFragment
@@ -1297,7 +1297,7 @@ public class SHACLValidator {
       case "GetRangeType2":
         query = getQuery((constraintType == CLASS_BASED_CONSTRAINT ? CYPHER_MATCH_WHERE : CYPHER_MATCH_ALL_WHERE),
                 tx, (constraintType == QUERY_BASED_CONSTRAINT ? customWhere + " and " : ""),
-                "exists(focus.`%s`) RETURN " + nodeIdFragment + nodeTypeFragment + shapeIdFragment
+                " focus.`%s` is not null RETURN " + nodeIdFragment + nodeTypeFragment + shapeIdFragment
                         + "'" + SHACL.CLASS_CONSTRAINT_COMPONENT
                         + "' as propertyShape, focus.`%s` as offendingValue, "
                         + propertyNameFragment + severityFragment
@@ -1381,25 +1381,25 @@ public class SHACLValidator {
       case "TypeAsNodeMinCardinality":
         query = getQuery((constraintType == CLASS_BASED_CONSTRAINT ? CYPHER_WITH_PARAMS_MATCH_WHERE : CYPHER_WITH_PARAMS_MATCH_ALL_WHERE),
                 tx, (constraintType == QUERY_BASED_CONSTRAINT ? customWhere + " and " : ""),
-                "NOT %s ( size((focus)-[:`%s`]->())) %s RETURN " + nodeIdFragment + nodeTypeFragment + shapeIdFragment
-                + "'%s' as propertyShape,  'type cardinality (' + coalesce(size((focus)-[:`%s`]->()),0) + ') is outside the defined min-max limits'  as message, "
+                "NOT %s ( size([(focus)-[rel:`%s`]->() | rel ])) %s RETURN " + nodeIdFragment + nodeTypeFragment + shapeIdFragment
+                + "'%s' as propertyShape,  'type cardinality (' + coalesce(size([(focus)-[rel:`%s`]->() | rel ]),0) + ') is outside the defined min-max limits'  as message, "
                 + propertyNameFragment + severityFragment
                 + " null as offendingValue , " + customMsgFragment);
         break;
       case "MinCardinality1":
         query = getQuery((constraintType == CLASS_BASED_CONSTRAINT ? CYPHER_WITH_PARAMS_MATCH_WHERE : CYPHER_WITH_PARAMS_MATCH_ALL_WHERE),
                 tx, (constraintType == QUERY_BASED_CONSTRAINT ? customWhere + " and " : ""),
-                "NOT %s ( size((focus)-[:`%s`]->()) +  size([] + coalesce(focus.`%s`, [])) ) %s RETURN "
+                "NOT %s ( size([(focus)-[rel:`%s`]->()| rel ]) +  size([] + coalesce(focus.`%s`, [])) ) %s RETURN "
                 + nodeIdFragment + nodeTypeFragment + shapeIdFragment
-                + "'%s' as propertyShape,  'cardinality (' + (coalesce(size((focus)-[:`%s`]->()),0) + coalesce(size([] + focus.`%s`),0)) + ') is outside the defined min-max limits'  as message, "
+                + "'%s' as propertyShape,  'cardinality (' + (coalesce(size([(focus)-[rel:`%s`]->()| rel ]),0) + coalesce(size([] + focus.`%s`),0)) + ') is outside the defined min-max limits'  as message, "
                 + propertyNameFragment + severityFragment
                 + "null as offendingValue , " + customMsgFragment);
         break;
       case "MinCardinality1Inverse":
         query = getQuery((constraintType == CLASS_BASED_CONSTRAINT ? CYPHER_WITH_PARAMS_MATCH_WHERE : CYPHER_WITH_PARAMS_MATCH_ALL_WHERE),
                 tx, (constraintType == QUERY_BASED_CONSTRAINT ? customWhere + " and " : ""),
-                "NOT %s size((focus)<-[:`%s`]-()) %s RETURN " + nodeIdFragment + nodeTypeFragment + shapeIdFragment
-                + "'%s' as propertyShape,  'incoming cardinality (' + coalesce(size((focus)<-[:`%s`]-()),0) +') is outside the defined min-max limits' as message, "
+                "NOT %s size([(focus)<-[rel:`%s`]-() | rel ]) %s RETURN " + nodeIdFragment + nodeTypeFragment + shapeIdFragment
+                + "'%s' as propertyShape,  'incoming cardinality (' + coalesce(size([ (focus)<-[rel:`%s`]-()| rel ]),0) +') is outside the defined min-max limits' as message, "
                 + propertyNameFragment + severityFragment
                 + "null as offendingValue , " + customMsgFragment);
         break;

--- a/src/test/java/DocsTest.java
+++ b/src/test/java/DocsTest.java
@@ -80,7 +80,7 @@ public class DocsTest {
     List<Row> rows = new ArrayList<>();
 
     List<Row> procedureRows = db.defaultDatabaseService().executeTransactionally(
-        "CALL dbms.procedures() YIELD signature, name, description WHERE name STARTS WITH 'n10s' RETURN 'procedure' AS type, name, description, signature ORDER BY signature",
+        "show procedures YIELD signature, name, description WHERE name STARTS WITH 'n10s' RETURN 'procedure' AS type, name, description, signature ORDER BY signature",
         Collections.emptyMap(),
         result -> result.stream().map(record -> new Row(
             record.get("type").toString(),
@@ -91,7 +91,7 @@ public class DocsTest {
     rows.addAll(procedureRows);
 
     List<Row> functionRows = db.defaultDatabaseService().executeTransactionally(
-        "CALL dbms.functions() YIELD signature, name, description WHERE name STARTS WITH 'n10s' RETURN 'function' AS type, name, description, signature ORDER BY signature",
+        "show functions YIELD signature, name, description WHERE name STARTS WITH 'n10s' RETURN 'function' AS type, name, description, signature ORDER BY signature",
         Collections.emptyMap(),
         result -> result.stream().map(record -> new Row(
             record.get("type").toString(),

--- a/src/test/java/n10s/ModelTestUtils.java
+++ b/src/test/java/n10s/ModelTestUtils.java
@@ -18,7 +18,6 @@ public class ModelTestUtils {
 
     Model expectedModel = createModel(expected, formatExpected);
     Model actualModel = createModel(actual, formatActual);
-
     return Models.isomorphic(expectedModel, actualModel);
   }
 

--- a/src/test/java/n10s/RDFExportTest.java
+++ b/src/test/java/n10s/RDFExportTest.java
@@ -557,10 +557,10 @@ public class RDFExportTest {
                       getNTriplesGraphFromSPOPattern(session,"http://base/about#nonexistingresource",DEFAULT_BASE_SCH_NS + "name", "MS", true, "http://www.w3.org/2001/XMLSchema#string", null), RDFFormat.NTRIPLES));
 
       expected = "{\n" +
-              "  \"@id\" : \"n4ind:8\",\n" +
+              "  \"@id\" : \"n4ind:" + emilId + "\",\n" +
               "  \"@type\" : \"n4sch:Person\",\n" +
               "  \"n4sch:ACTED_IN\" : {\n" +
-              "    \"@id\" : \"n4ind:0\"\n" +
+              "    \"@id\" : \"n4ind:" + theMatrixId + "\"\n" +
               "  },\n" +
               "  \"n4sch:born\" : {\n" +
               "    \"@type\" : \"http://www.w3.org/2001/XMLSchema#long\",\n" +
@@ -578,7 +578,7 @@ public class RDFExportTest {
                       getNTriplesGraphFromSPOPattern(session,BASE_INDIV_NS + emilId,null, null, false, null, null), RDFFormat.NTRIPLES));
 
       expected = "{\n" +
-              "  \"@id\" : \"n4ind:8\",\n" +
+              "  \"@id\" : \"n4ind:" + emilId + "\",\n" +
               "  \"n4sch:name\" : \"Emil Eifrem\",\n" +
               "  \"@context\" : {\n" +
               "    \"n4sch\" : \"neo4j://graph.schema#\",\n" +
@@ -592,7 +592,7 @@ public class RDFExportTest {
 
 
       expected = "{\n" +
-              "  \"@id\" : \"n4ind:8\",\n" +
+              "  \"@id\" : \"n4ind:" + emilId + "\",\n" +
               "  \"@type\" : \"n4sch:Person\",\n" +
               "  \"@context\" : {\n" +
               "    \"n4sch\" : \"neo4j://graph.schema#\",\n" +
@@ -607,7 +607,7 @@ public class RDFExportTest {
 
 
       expected = "{\n" +
-              "  \"@id\" : \"n4ind:8\",\n" +
+              "  \"@id\" : \"n4ind:" + emilId + "\",\n" +
               "  \"n4sch:name\" : \"Emil Eifrem\",\n" +
               "  \"@context\" : {\n" +
               "    \"n4sch\" : \"neo4j://graph.schema#\",\n" +
@@ -620,7 +620,7 @@ public class RDFExportTest {
                       getNTriplesGraphFromSPOPattern(session,BASE_INDIV_NS + emilId,DEFAULT_BASE_SCH_NS + "name", "Emil Eifrem", true, "http://www.w3.org/2001/XMLSchema#string", null), RDFFormat.NTRIPLES));
 
       expected = "{\n" +
-              "  \"@id\" : \"n4ind:8\",\n" +
+              "  \"@id\" : \"n4ind:" + emilId + "\",\n" +
               "  \"n4sch:born\" : {\n" +
               "    \"@type\" : \"http://www.w3.org/2001/XMLSchema#long\",\n" +
               "    \"@value\" : \"1978\"\n" +
@@ -645,7 +645,7 @@ public class RDFExportTest {
 
 
       expected = "{\n" +
-              "  \"@id\" : \"n4ind:8\",\n" +
+              "  \"@id\" : \"n4ind:" + emilId + "\",\n" +
               "  \"@type\" : \"n4sch:Person\",\n" +
               "  \"@context\" : {\n" +
               "    \"n4sch\" : \"neo4j://graph.schema#\",\n" +
@@ -683,55 +683,20 @@ public class RDFExportTest {
               .compareModels("{}", RDFFormat.JSONLD,
                       getNTriplesGraphFromSPOPattern(session,null,"http://undefinedvoc.org/name", null, false, null, null), RDFFormat.NTRIPLES));
 
-
-      // if we hardcode the ids here what's the point of getting them at the beginning for Emil, Renier and The Matrix?
-      //TODO: do this right
-      String titleTriples = "<neo4j://graph.individuals#0> <neo4j://graph.schema#title> \"The Matrix\" .\n" +
-              "<neo4j://graph.individuals#9> <neo4j://graph.schema#title> \"The Matrix Reloaded\" .\n" +
-              "<neo4j://graph.individuals#10> <neo4j://graph.schema#title> \"The Matrix Revolutions\" .\n" +
-              "<neo4j://graph.individuals#11> <neo4j://graph.schema#title> \"The Devil's Advocate\" .\n" +
-              "<neo4j://graph.individuals#15> <neo4j://graph.schema#title> \"A Few Good Men\" .\n" +
-              "<neo4j://graph.individuals#29> <neo4j://graph.schema#title> \"Top Gun\" .\n" +
-              "<neo4j://graph.individuals#37> <neo4j://graph.schema#title> \"Jerry Maguire\" .\n" +
-              "<neo4j://graph.individuals#46> <neo4j://graph.schema#title> \"Stand By Me\" .\n" +
-              "<neo4j://graph.individuals#52> <neo4j://graph.schema#title> \"As Good as It Gets\" .\n" +
-              "<neo4j://graph.individuals#56> <neo4j://graph.schema#title> \"What Dreams May Come\" .\n" +
-              "<neo4j://graph.individuals#62> <neo4j://graph.schema#title> \"Snow Falling on Cedars\" .\n" +
-              "<neo4j://graph.individuals#67> <neo4j://graph.schema#title> \"You've Got Mail\" .\n" +
-              "<neo4j://graph.individuals#73> <neo4j://graph.schema#title> \"Sleepless in Seattle\" .\n" +
-              "<neo4j://graph.individuals#78> <neo4j://graph.schema#title> \"Joe Versus the Volcano\" .\n" +
-              "<neo4j://graph.individuals#81> <neo4j://graph.schema#title> \"When Harry Met Sally\" .\n" +
-              "<neo4j://graph.individuals#85> <neo4j://graph.schema#title> \"That Thing You Do\" .\n" +
-              "<neo4j://graph.individuals#87> <neo4j://graph.schema#title> \"The Replacements\" .\n" +
-              "<neo4j://graph.individuals#92> <neo4j://graph.schema#title> \"RescueDawn\" .\n" +
-              "<neo4j://graph.individuals#95> <neo4j://graph.schema#title> \"The Birdcage\" .\n" +
-              "<neo4j://graph.individuals#97> <neo4j://graph.schema#title> \"Unforgiven\" .\n" +
-              "<neo4j://graph.individuals#100> <neo4j://graph.schema#title> \"Johnny Mnemonic\" .\n" +
-              "<neo4j://graph.individuals#105> <neo4j://graph.schema#title> \"Cloud Atlas\" .\n" +
-              "<neo4j://graph.individuals#111> <neo4j://graph.schema#title> \"The Da Vinci Code\" .\n" +
-              "<neo4j://graph.individuals#116> <neo4j://graph.schema#title> \"V for Vendetta\" .\n" +
-              "<neo4j://graph.individuals#121> <neo4j://graph.schema#title> \"Speed Racer\" .\n" +
-              "<neo4j://graph.individuals#128> <neo4j://graph.schema#title> \"Ninja Assassin\" .\n" +
-              "<neo4j://graph.individuals#130> <neo4j://graph.schema#title> \"The Green Mile\" .\n" +
-              "<neo4j://graph.individuals#137> <neo4j://graph.schema#title> \"Frost/Nixon\" .\n" +
-              "<neo4j://graph.individuals#141> <neo4j://graph.schema#title> \"Hoffa\" .\n" +
-              "<neo4j://graph.individuals#144> <neo4j://graph.schema#title> \"Apollo 13\" .\n" +
-              "<neo4j://graph.individuals#147> <neo4j://graph.schema#title> \"Twister\" .\n" +
-              "<neo4j://graph.individuals#150> <neo4j://graph.schema#title> \"Cast Away\" .\n" +
-              "<neo4j://graph.individuals#152> <neo4j://graph.schema#title> \"One Flew Over the Cuckoo's Nest\" .\n" +
-              "<neo4j://graph.individuals#154> <neo4j://graph.schema#title> \"Something's Gotta Give\" .\n" +
-              "<neo4j://graph.individuals#157> <neo4j://graph.schema#title> \"Bicentennial Man\" .\n" +
-              "<neo4j://graph.individuals#159> <neo4j://graph.schema#title> \"Charlie Wilson's War\" .\n" +
-              "<neo4j://graph.individuals#161> <neo4j://graph.schema#title> \"The Polar Express\" .\n" +
-              "<neo4j://graph.individuals#162> <neo4j://graph.schema#title> \"A League of Their Own\" .";
-
+      StringBuilder titleTriplesSb = new StringBuilder();
+      Result titlesQueryResult = session.run("MATCH (n:Movie) RETURN id(n) as id, n.title as title ");
+      while(titlesQueryResult.hasNext()){
+        Record movie = titlesQueryResult.next();
+        titleTriplesSb.append("<neo4j://graph.individuals#").append(movie.get("id").asLong()).append("> <neo4j://graph.schema#title> \"")
+                .append(movie.get("title").asString()).append("\" .\n");
+      }
 
       assertTrue(ModelTestUtils
-              .compareModels(titleTriples, RDFFormat.NTRIPLES,
+              .compareModels(titleTriplesSb.toString(), RDFFormat.NTRIPLES,
                       getNTriplesGraphFromSPOPattern(session,null,DEFAULT_BASE_SCH_NS + "title", null, false, null, null), RDFFormat.NTRIPLES));
 
       expected = "{\n" +
-              "  \"@id\" : \"n4ind:8\",\n" +
+              "  \"@id\" : \"n4ind:" + emilId + "\",\n" +
               "  \"n4sch:born\" : {\n" +
               "    \"@type\" : \"http://www.w3.org/2001/XMLSchema#long\",\n" +
               "    \"@value\" : \"1978\"\n" +
@@ -769,19 +734,17 @@ public class RDFExportTest {
         { criticTypesTriples.append("<" + BASE_INDIV_NS + id + "> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <" + DEFAULT_BASE_SCH_NS +  "Critic> .\n");
           criticTypesTriples.append("<" + BASE_INDIV_NS + id + "> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <" + DEFAULT_BASE_SCH_NS +  "Person> .\n");} );
 
-      String someMovies = "<neo4j://graph.individuals#0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <neo4j://graph.schema#Movie> .\n" +
-              "<neo4j://graph.individuals#9> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <neo4j://graph.schema#Movie> .\n" +
-              "<neo4j://graph.individuals#10> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <neo4j://graph.schema#Movie> .\n" +
-              "<neo4j://graph.individuals#11> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <neo4j://graph.schema#Movie> .\n" +
-              "<neo4j://graph.individuals#15> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <neo4j://graph.schema#Movie> .\n" +
-              "<neo4j://graph.individuals#29> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <neo4j://graph.schema#Movie> .\n" +
-              "<neo4j://graph.individuals#37> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <neo4j://graph.schema#Movie> .\n" +
-              "<neo4j://graph.individuals#46> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <neo4j://graph.schema#Movie> .\n" +
-              "<neo4j://graph.individuals#52> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <neo4j://graph.schema#Movie> .\n" ;
+      StringBuilder someMoviesSb = new StringBuilder();
+      Result someMoviesQueryResult = session.run("MATCH (n:Movie) RETURN id(n) as id skip 30 limit 10");
+      while(someMoviesQueryResult.hasNext()){
+        Record movie = someMoviesQueryResult.next();
+        someMoviesSb.append("<neo4j://graph.individuals#").append(movie.get("id").asLong())
+                .append("> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <neo4j://graph.schema#Movie> .\n");
+      }
 
       assertTrue(ModelTestUtils
               .modelContains(getNTriplesGraphFromSPOPattern(session,null,"http://www.w3.org/1999/02/22-rdf-syntax-ns#type", null, false, null, null), RDFFormat.NTRIPLES,
-              criticTypesTriples.toString() + someMovies, RDFFormat.NTRIPLES));
+              criticTypesTriples.toString() + someMoviesSb.toString(), RDFFormat.NTRIPLES));
 
       StringBuilder criticTypesTriples2  = new StringBuilder();
       critics.forEach(id-> criticTypesTriples2.append("<" + BASE_INDIV_NS + id + "> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <" + DEFAULT_BASE_SCH_NS +  "Critic> .\n") );
@@ -792,7 +755,7 @@ public class RDFExportTest {
 
       String allGraphAsNTriples = getNTriplesGraphFromSPOPattern(session, null, null, null, false, null, null);
       assertTrue(ModelTestUtils.modelContains(allGraphAsNTriples, RDFFormat.NTRIPLES,
-                      criticTypesTriples.toString() + someMovies + titleTriples, RDFFormat.NTRIPLES ));
+                      criticTypesTriples.toString() + someMoviesSb.toString() + titleTriplesSb.toString(), RDFFormat.NTRIPLES ));
 
       assertFalse(ModelTestUtils.modelContains(allGraphAsNTriples, RDFFormat.NTRIPLES,
               "<neo4j://graph.individuals#0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <neo4j://graph.schema#AwesomeMovie> ." , RDFFormat.NTRIPLES ));

--- a/src/test/java/n10s/RDFProceduresTest.java
+++ b/src/test/java/n10s/RDFProceduresTest.java
@@ -30,13 +30,13 @@ import n10s.quadrdf.delete.QuadRDFDeleteProcedures;
 import n10s.quadrdf.load.QuadRDFLoadProcedures;
 import n10s.rdf.RDFProcedures;
 import n10s.rdf.delete.RDFDeleteProcedures;
+import n10s.rdf.export.RDFExportProcedures;
 import n10s.rdf.load.RDFLoadProcedures;
 import n10s.rdf.preview.RDFPreviewProcedures;
 import n10s.rdf.stream.RDFStreamProcedures;
 import n10s.skos.load.SKOSLoadProcedures;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.neo4j.driver.Config;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
@@ -56,21 +56,37 @@ import org.neo4j.harness.junit.rule.Neo4jRule;
  * Created by jbarrasa on 21/03/2016.
  */
 public class RDFProceduresTest {
+  public static Driver driver;
 
-  @Rule
-  public Neo4jRule neo4j = new Neo4jRule()
-      .withProcedure(RDFLoadProcedures.class)
-      .withProcedure(RDFDeleteProcedures.class)
-      .withProcedure(RDFPreviewProcedures.class)
-      .withProcedure(RDFStreamProcedures.class)
-      .withFunction(RDFProcedures.class)
-      .withProcedure(QuadRDFLoadProcedures.class)
-      .withProcedure(QuadRDFDeleteProcedures.class)
-      .withProcedure(MappingUtils.class)
-      .withProcedure(GraphConfigProcedures.class)
-      .withProcedure(NsPrefixDefProcedures.class)
-      .withProcedure(ExperimentalImports.class)
-      .withProcedure(SKOSLoadProcedures.class);
+  @ClassRule
+  public static Neo4jRule neo4j = new Neo4jRule()
+          .withProcedure(RDFLoadProcedures.class)
+          .withProcedure(RDFDeleteProcedures.class)
+          .withProcedure(RDFPreviewProcedures.class)
+          .withProcedure(RDFStreamProcedures.class)
+          .withFunction(RDFProcedures.class)
+          .withProcedure(QuadRDFLoadProcedures.class)
+          .withProcedure(QuadRDFDeleteProcedures.class)
+          .withProcedure(MappingUtils.class)
+          .withProcedure(GraphConfigProcedures.class)
+          .withProcedure(NsPrefixDefProcedures.class)
+          .withProcedure(ExperimentalImports.class)
+          .withProcedure(SKOSLoadProcedures.class);
+
+  @BeforeClass
+  public static void init() {
+    driver = GraphDatabase.driver(neo4j.boltURI(),
+            Config.builder().withoutEncryption().build());
+  }
+
+  @Before
+  public void cleanDatabase() {
+    driver.session().run("match (n) detach delete n").consume();
+    driver.session().run("drop constraint n10s_unique_uri if exists").consume();
+    driver.session().run("drop index uri_index if exists").consume();
+  }
+
+  final String CREATE_URI_INDEX = "CREATE INDEX uri_index FOR (n:Resource) ON (n.uri)";
 
   private String jsonLdFragment = "{\n" +
       "  \"@context\": {\n" +
@@ -352,8 +368,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testAbortIfNoIndices() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       Result importResults
           = session.run("CALL n10s.rdf.import.fetch('" +
@@ -373,8 +388,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testFullTextIndexesPresent() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       session.run("CREATE FULLTEXT INDEX titlesAndDescriptions FOR (n:Movie|Book) ON EACH [n.title, n.description]");
 
@@ -394,10 +408,8 @@ public class RDFProceduresTest {
 
   @Test
   public void testCompositeIndexesPresent() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
-
-      session.run("CREATE INDEX FOR (p:Person) ON (p.age, p.country)");
+    try (Session session = driver.session()) {
+      session.run("CREATE INDEX IF NOT EXISTS FOR (n:Person) ON (n.age, n.country)");
 
       Result importResults
           = session.run("CALL n10s.rdf.import.fetch('file:///fileDoesnotExist.txt','JSON-LD',{})");
@@ -416,10 +428,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testAbortIfNoIndicesImportSnippet() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
-      Session session = driver.session();
+    try (Session session = driver.session();) {
 
       Result importResults1 = session.run("CALL n10s.rdf.import.inline('" +
           turtleFragment +
@@ -437,8 +446,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportJSONLD() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS' }");
@@ -466,8 +474,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testInvalidSerialisationFormat() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS' }");
@@ -524,8 +531,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportZippedSingleFile() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS' }");
@@ -605,8 +611,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportZippedMultiFile() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS' }");
@@ -639,8 +644,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportSKOSInline() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'IGNORE', handleMultival: 'ARRAY' }");
@@ -664,8 +668,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportSKOSFetchWithParams() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               "{}");
@@ -695,8 +698,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportSKOSFetchWithParamsCustomSchemaNs() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               "{ baseSchemaNamespace: 'http://baseschema.mine/voc1#' , " +
@@ -727,8 +729,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportRDFStar () throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'IGNORE' }");
@@ -754,8 +755,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportRDFStarWithArrayMultiVal () throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               "{ handleVocabUris: 'IGNORE' , " +
@@ -785,8 +785,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportSKOSFetchMultivalArray() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleMultival: 'ARRAY', keepLangTag: true }");
@@ -819,11 +818,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportJSONLDImportSnippet() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
-      Session session = driver.session();
-
+    try (Session session = driver.session();) {
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           " { handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS'} ");
 
@@ -844,11 +839,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportTurtleSnippetWithPoints() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build())) {
-
-      Session session = driver.session();
-
+    try (Session session = driver.session();) {
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               " { handleVocabUris: 'SHORTEN' } ");
 
@@ -891,8 +882,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportJSONLDShortening() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'SHORTEN', handleRDFTypes: 'LABELS' }");
@@ -948,14 +938,12 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportJSONLDShorteningStrict() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session();) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'SHORTEN_STRICT', handleRDFTypes: 'LABELS' }");
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       Result importResults
           = session.run("CALL n10s.rdf.import.fetch('" +
           RDFProceduresTest.class.getClassLoader().getResource("mini-ld.json").toURI()
@@ -972,8 +960,7 @@ public class RDFProceduresTest {
           + "namespace <http://xmlns.com/foaf/0.1/> and 'handleVocabUris' is set "
           + "to 'SHORTEN_STRICT'", e.getMessage());
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       assertEquals("one",
           session.run("call n10s.nsprefixes.add('one','http://xmlns.com/foaf/0.1/')").next()
               .get("prefix").asString());
@@ -1001,8 +988,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportRDFXML() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS' }");
@@ -1032,8 +1018,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportRDFXMLShortening() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -1068,8 +1053,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportRDFXMLShorteningWithPrefixPreDefinition() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
       session.run("call n10s.nsprefixes.add('dct','http://purl.org/dc/terms/')");
@@ -1110,8 +1094,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportRDFXMLShorteningWithPrefixPreDefinitionOneTriple() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
       session.run("call n10s.nsprefixes.add('voc','http://neo4j.com/voc/')");
@@ -1137,8 +1120,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportBadUrisTtl() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'SHORTEN', handleRDFTypes: 'LABELS' }");
@@ -1161,8 +1143,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportTtlBadUrisException() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -1186,8 +1167,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportRDFXMLBadUris() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
       session.run("call n10s.nsprefixes.add('voc','http://neo4j.com/voc/')");
@@ -1208,8 +1188,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportLangFilter() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -1280,8 +1259,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportMultivalLangTag() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ keepLangTag : true, handleMultival: 'ARRAY'}");
@@ -1309,8 +1287,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportMultivalWithMultivalList() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleMultival: 'ARRAY', " +
@@ -1348,8 +1325,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportMultivalWithExclusionList() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleMultival: 'ARRAY' }");
@@ -1383,8 +1359,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportTurtle() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS' }");
@@ -1418,8 +1393,7 @@ public class RDFProceduresTest {
    */
   @Test
   public void testImportTurtle02() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
       session.run("call n10s.nsprefixes.add('ex','http://www.example.com/ontology/1.0.0#')");
@@ -1443,8 +1417,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPreviewFromSnippetPassWrongUri() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{handleVocabUris: 'KEEP', handleRDFTypes: 'NODES' }");
@@ -1464,8 +1437,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPreviewFromSnippetFailWrongUri() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'NODES'}");
@@ -1488,8 +1460,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPreviewFromSnippet() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'NODES'}");
@@ -1508,8 +1479,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPreviewFromSnippetLimit() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'NODES'}");
@@ -1542,8 +1512,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPreviewFromFileLimit() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'NODES'}");
@@ -1580,8 +1549,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPreviewRDFStarFromSnippet() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{handleVocabUris: 'IGNORE'}");
@@ -1603,8 +1571,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testRDFStarWithTriplesAsObjectFromSnippet() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               "{handleVocabUris: 'IGNORE'}");
@@ -1624,8 +1591,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testLoadFromSnippetCreateNodes() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'NODES'}");
@@ -1650,8 +1616,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testLoadFromSnippetCreateNodesAndLabels() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'SHORTEN', handleRDFTypes: 'LABELS_AND_NODES'}");
@@ -1676,8 +1641,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPreviewFromSnippetLangFilter() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'NODES' }");
@@ -1712,8 +1676,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPointDatatype() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               "{handleVocabUris: 'IGNORE'}");
@@ -1755,8 +1718,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPointDatatypeInMars() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               "{handleVocabUris: 'IGNORE'}");
@@ -1777,8 +1739,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPreviewFromFile() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'NODES' }");
@@ -1799,8 +1760,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPreviewFromBadUriFile() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -1821,8 +1781,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPreviewFromBadUriFileFail() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'NODES'}");
@@ -1846,8 +1805,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testPreviewFromFileLangFilter() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'NODES', keepLangTag : false }");
@@ -1878,14 +1836,12 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportFromFileWithMapping() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       session.run("call n10s.nsprefixes.add('voc','http://neo4j.com/voc/')");
       session.run("call n10s.nsprefixes.add('cats','http://neo4j.com/category/')");
     }
 
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "{ handleVocabUris: 'MAP'}");
 
@@ -1916,8 +1872,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportFromFileIgnoreNs() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "{ handleVocabUris: 'IGNORE'}");
 
@@ -1946,8 +1901,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportFromFileIgnoreNsApplyNeoNaming() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'IGNORE', applyNeo4jNaming: true }");
@@ -1978,14 +1932,12 @@ public class RDFProceduresTest {
   @Test
   public void testImportFromFileWithPredFilter() throws Exception {
 
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       session.run("call n10s.nsprefixes.add('sch','http://schema.org/')");
       session.run("call n10s.nsprefixes.add('cats','http://neo4j.com/category/')");
     }
 
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),"{ handleVocabUris: 'MAP'}");
 
@@ -2022,8 +1974,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testStreamFromFile() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       Result importResults
           = session.run("CALL n10s.rdf.stream.fetch('" +
@@ -2042,8 +1993,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testStreamFromFileWithLimit() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       Result importResults
           = session.run("CALL n10s.rdf.stream.fetch('" +
@@ -2058,8 +2008,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testStreamFromFileWithExclusionList() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       String filteredPred = "http://schema.org/image";
 
@@ -2102,8 +2051,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testStreamFromString() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       String rdf = "<rdf:RDF xmlns:owl=\"http://www.w3.org/2002/07/owl#\"\n"
           + "         xmlns:rdfs=\"http://www.w3.org/2000/01/rdf-schema#\"\n"
@@ -2129,8 +2077,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testStreamFromBadUriFile() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       Result importResults
           = session.run("CALL n10s.rdf.stream.fetch('" +
@@ -2149,8 +2096,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testStreamFromBadUriString() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       String rdf = "@prefix pr: <http://example.org/vocab/show/> .\n"
           + "pr:ent\n"
@@ -2172,8 +2118,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testStreamFromBadUriFileFail() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       try {
         Result importResults
@@ -2190,8 +2135,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testStreamRDFStarFromSnippet() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       Result importResults
               = session
@@ -2232,8 +2176,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testGetLangValUDF() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -2296,8 +2239,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testGetLangTagUDF() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -2334,8 +2276,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testHasLangTagUDF() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -2374,8 +2315,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testGetUriFromShortAndShortFromUri() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'SHORTEN', handleRDFTypes: 'LABELS' }");
@@ -2402,8 +2342,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testGetDataType() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -2447,8 +2386,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testGetValue() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -2474,8 +2412,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testCustomDataTypesKeepURIs() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ keepLangTag: true, handleMultival: 'ARRAY',  " +
@@ -2511,8 +2448,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testCustomDataTypesShortenURIs() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           " { keepLangTag: true, handleMultival: 'ARRAY',  " +
@@ -2553,8 +2489,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportMultiValAfterImportSingelVal() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleMultival: 'OVERWRITE', handleVocabUris: 'KEEP'  }");
@@ -2593,8 +2528,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testReificationImport() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS' }");
@@ -2628,8 +2562,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testIncrementalLoadMultivaluesInArray() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "{ handleMultival: 'ARRAY' }");
 
@@ -2660,8 +2593,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testIncrementalLoadNamespaces() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -2706,8 +2638,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testLoadNamespacesWithCustomPredefined() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -2744,8 +2675,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testIncrementalLoadArrayOnPreviouslyAtomicValue() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -2791,8 +2721,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testIncrementalLoadAtomicValueOnPreviouslyArray() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -2818,10 +2747,10 @@ public class RDFProceduresTest {
     }
   }
 
+  @Ignore
   @Test
   public void testLargerFileManyTransactions() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -2837,8 +2766,7 @@ public class RDFProceduresTest {
 
   @Test
   public void dbpediaFragmentTest() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "{handleMultival:'ARRAY', handleRDFTypes: 'NODES'}");
 
@@ -2876,8 +2804,7 @@ public class RDFProceduresTest {
 
   @Test
   public void multivalMultitypeSamePartialTx() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "{handleMultival:'ARRAY', handleRDFTypes: 'NODES'}");
 
@@ -2952,8 +2879,7 @@ public class RDFProceduresTest {
 
   @Test
   public void homogeneousMultivalAcrossPartialCommits() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "{handleMultival:'ARRAY', handleRDFTypes: 'NODES'}");
 
@@ -2993,8 +2919,7 @@ public class RDFProceduresTest {
 
   @Test
   public void heterogeneousMultivalAcrossPartialCommits() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               "{handleMultival:'ARRAY', handleRDFTypes: 'NODES', keepCustomDataTypes: true}");
@@ -3121,8 +3046,7 @@ public class RDFProceduresTest {
 
   @Test
   public void heterogeneousMultivalAcrossPartialCommitsWithKeepURIs() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               "{handleMultival:'ARRAY', handleVocabUris: 'KEEP', keepCustomDataTypes: true}");
@@ -3157,8 +3081,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testTypesOnlySeparateTx() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
               "{handleMultival:'ARRAY', keepCustomDataTypes: true}");
@@ -3184,8 +3107,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testDeleteRelationshipKeepURIs() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS', keepCustomDataTypes: true, handleMultival: 'ARRAY'}");
@@ -3226,8 +3148,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testDeleteRelationshipShortenURIs() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -3268,8 +3189,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testDeleteRelationshipShortenURIsFromString() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -3334,8 +3254,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testDeleteLiteralKeepURIs() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS', " +
@@ -3371,8 +3290,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testDeleteLiteralShortenURIs() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           " { handleVocabUris: 'SHORTEN', handleRDFTypes: 'LABELS', " +
@@ -3408,8 +3326,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testDeleteLiteralShortenURIsFromString() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'SHORTEN', handleRDFTypes: 'LABELS', keepCustomDataTypes: true, handleMultival: 'ARRAY'}");
@@ -3470,8 +3387,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testDeleteTypeFromResource() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -3506,8 +3422,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testDeleteAllTriplesRelatedToResource() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -3537,8 +3452,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testDeleteMultiLiteral() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(),
           "{handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS', keepCustomDataTypes: true, " +
@@ -3593,8 +3507,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testDeleteSubjectNode() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -3628,8 +3541,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testRepetitiveDeletion() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "" +
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS', keepCustomDataTypes: true, handleMultival: 'ARRAY'}");
@@ -3667,11 +3579,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportDatesAndTimes() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
-      Session session = driver.session();
-
+    try (Session session = driver.session();) {
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
       Result importResults1 = session.run("CALL n10s.rdf.import.fetch('" +
@@ -3691,11 +3599,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportDatesAndTimes2() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
-      Session session = driver.session();
-
+    try (Session session = driver.session();) {
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
       Result importResults1 = session.run("CALL n10s.rdf.import.fetch('" +
@@ -3715,10 +3619,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportDatesAndTimesMultivalued() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
-      Session session = driver.session();
+    try (Session session = driver.session();) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "{ handleMultival: 'ARRAY' }");
 
@@ -3758,8 +3659,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportQuadRDFTriG() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDBForQuads(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS', keepCustomDataTypes: true, handleMultival: 'ARRAY' }");
@@ -3830,13 +3730,11 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportInlineQuadRDFTriG() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       session.run("call n10s.nsprefixes.add('ns0','http://www.example.org/vocabulary#')");
     }
 
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDBForQuads(neo4j.defaultDatabaseService(),
           "{ keepCustomDataTypes: true, handleMultival: 'ARRAY' }");
@@ -3906,8 +3804,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testImportQuadRDFNQuads() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDBForQuads(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS', keepCustomDataTypes: true, handleMultival: 'ARRAY' }");
@@ -3978,8 +3875,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testDeleteQuadRDFTriG() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDBForQuads(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS', keepCustomDataTypes: true, handleMultival: 'ARRAY' }");
@@ -4010,8 +3906,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testDeleteQuadRDFNQuads() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDBForQuads(neo4j.defaultDatabaseService(),
           " { handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS', keepCustomDataTypes: true, handleMultival: 'ARRAY' } ");
@@ -4042,8 +3937,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testRepetitiveDeletionQuadRDF() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDBForQuads(neo4j.defaultDatabaseService(),
           "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS', keepCustomDataTypes: true, handleMultival: 'ARRAY'}");
@@ -4086,7 +3980,7 @@ public class RDFProceduresTest {
   }
 
   private void initialiseGraphDBForQuads(GraphDatabaseService db, String graphConfigParams) {
-    db.executeTransactionally("create index for (n:Resource) on (n.uri)");
+    db.executeTransactionally(CREATE_URI_INDEX);
     db.executeTransactionally("CALL n10s.graphconfig.init(" +
         (graphConfigParams != null ? graphConfigParams : "{}") + ")");
   }
@@ -4094,8 +3988,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testLoadJSONAsTreeEmptyJSON() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), null);
 
@@ -4110,8 +4003,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testLoadJSONAsTreeListAtRoot() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "{ handleVocabUris: 'IGNORE' }");
 
@@ -4149,8 +4041,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testLoadJSONAsTree() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "{ handleVocabUris: 'IGNORE' }");
 
@@ -4185,8 +4076,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testLoadJSONAsTreeWithUrisAndContext() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "{ handleVocabUris: 'IGNORE' }");
 
@@ -4240,8 +4130,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testLoadJSONAsTree2() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "{ handleVocabUris: 'IGNORE' }");
 
@@ -4295,8 +4184,7 @@ public class RDFProceduresTest {
 
   @Test
   public void testLoadJSONAsTree3() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       initialiseGraphDB(neo4j.defaultDatabaseService(), "{ handleVocabUris: 'IGNORE' }");
 

--- a/src/test/java/n10s/RDFProceduresTest.java
+++ b/src/test/java/n10s/RDFProceduresTest.java
@@ -2746,8 +2746,7 @@ public class RDFProceduresTest {
 
     }
   }
-
-  @Ignore
+  
   @Test
   public void testLargerFileManyTransactions() throws Exception {
     try (Session session = driver.session()) {

--- a/src/test/java/n10s/aux/AuxProceduresTest.java
+++ b/src/test/java/n10s/aux/AuxProceduresTest.java
@@ -1,8 +1,13 @@
 package n10s.aux;
 
+import n10s.graphconfig.GraphConfigProcedures;
+import n10s.nsprefixes.NsPrefixDefProcedures;
+import n10s.rdf.aggregate.CollectTriples;
+import n10s.rdf.export.RDFExportProcedures;
+import n10s.rdf.load.RDFLoadProcedures;
+import n10s.rdf.stream.RDFStreamProcedures;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.neo4j.driver.*;
 import org.neo4j.driver.Record;
 import org.neo4j.harness.junit.rule.Neo4jRule;
@@ -10,100 +15,112 @@ import static n10s.graphconfig.Params.WKTLITERAL_URI;
 import static org.junit.Assert.*;
 
 public class AuxProceduresTest {
-    @Rule
-    public Neo4jRule neo4j = new Neo4jRule().withFunction(AuxProcedures.class);
 
+    public static Driver driver;
+
+    @ClassRule
+    public static Neo4jRule neo4j = new Neo4jRule()
+            .withFunction(AuxProcedures.class);
+
+    @BeforeClass
+    public static void init() {
+        driver = GraphDatabase.driver(neo4j.boltURI(),
+                Config.builder().withoutEncryption().build());
+    }
+
+    @Before
+    public void cleanDatabase() {
+        driver.session().run("match (n) detach delete n").consume();
+        driver.session().run("drop constraint n10s_unique_uri if exists");
+    }
     @Test
     public void testAddNamespacePrefixInitial() throws Exception {
-        try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-                Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+        Session session = driver.session();
 
-            Result res = session.run("RETURN n10s.aux.dt.check('" + XMLSchema.DATETIME.stringValue() + "',datetime()) as yes," +
-                    "n10s.aux.dt.check('"+ WKTLITERAL_URI.stringValue() +"',datetime()) as no1," +
-                    "n10s.aux.dt.check('" + XMLSchema.DATE.stringValue() + "',datetime()) as no2," +
-                    "n10s.aux.dt.check('" + XMLSchema.TIME.stringValue() +"',datetime()) as no3");
-            assertTrue(res.hasNext());
-            Record record = res.next();
-            assertTrue(record.get("yes").asBoolean());
-            assertFalse(record.get("no1").asBoolean());
-            assertFalse(record.get("no2").asBoolean());
-            assertFalse(record.get("no3").asBoolean());
+        Result res = session.run("RETURN n10s.aux.dt.check('" + XMLSchema.DATETIME.stringValue() + "',datetime()) as yes," +
+                "n10s.aux.dt.check('"+ WKTLITERAL_URI.stringValue() +"',datetime()) as no1," +
+                "n10s.aux.dt.check('" + XMLSchema.DATE.stringValue() + "',datetime()) as no2," +
+                "n10s.aux.dt.check('" + XMLSchema.TIME.stringValue() +"',datetime()) as no3");
+        assertTrue(res.hasNext());
+        Record record = res.next();
+        assertTrue(record.get("yes").asBoolean());
+        assertFalse(record.get("no1").asBoolean());
+        assertFalse(record.get("no2").asBoolean());
+        assertFalse(record.get("no3").asBoolean());
 
-            res = session.run("RETURN n10s.aux.dt.check('" + WKTLITERAL_URI.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as yes," +
-                    "n10s.aux.dt.check('" + XMLSchema.DATETIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no1," +
-                    "n10s.aux.dt.check('" + XMLSchema.DATE.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no2," +
-                    "n10s.aux.dt.check('" + XMLSchema.TIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no3");
-            assertTrue(res.hasNext());
-            record = res.next();
-            assertTrue(record.get("yes").asBoolean());
-            assertFalse(record.get("no1").asBoolean());
-            assertFalse(record.get("no2").asBoolean());
-            assertFalse(record.get("no3").asBoolean());
+        res = session.run("RETURN n10s.aux.dt.check('" + WKTLITERAL_URI.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as yes," +
+                "n10s.aux.dt.check('" + XMLSchema.DATETIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no1," +
+                "n10s.aux.dt.check('" + XMLSchema.DATE.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no2," +
+                "n10s.aux.dt.check('" + XMLSchema.TIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no3");
+        assertTrue(res.hasNext());
+        record = res.next();
+        assertTrue(record.get("yes").asBoolean());
+        assertFalse(record.get("no1").asBoolean());
+        assertFalse(record.get("no2").asBoolean());
+        assertFalse(record.get("no3").asBoolean());
 
-            res = session.run("RETURN n10s.aux.dt.check('" + WKTLITERAL_URI.stringValue() + "',45) as no0," +
-                    "n10s.aux.dt.check('" + XMLSchema.DATETIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no1," +
-                    "n10s.aux.dt.check('" + XMLSchema.DATE.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no2," +
-                    "n10s.aux.dt.check('" + XMLSchema.TIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no3");
-            assertTrue(res.hasNext());
-            record = res.next();
-            assertFalse(record.get("no0").asBoolean());
-            assertFalse(record.get("no1").asBoolean());
-            assertFalse(record.get("no2").asBoolean());
-            assertFalse(record.get("no3").asBoolean());
+        res = session.run("RETURN n10s.aux.dt.check('" + WKTLITERAL_URI.stringValue() + "',45) as no0," +
+                "n10s.aux.dt.check('" + XMLSchema.DATETIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no1," +
+                "n10s.aux.dt.check('" + XMLSchema.DATE.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no2," +
+                "n10s.aux.dt.check('" + XMLSchema.TIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no3");
+        assertTrue(res.hasNext());
+        record = res.next();
+        assertFalse(record.get("no0").asBoolean());
+        assertFalse(record.get("no1").asBoolean());
+        assertFalse(record.get("no2").asBoolean());
+        assertFalse(record.get("no3").asBoolean());
 
-            res = session.run("RETURN n10s.aux.dt.check('" + WKTLITERAL_URI.stringValue() + "',true) as no0," +
-                    "n10s.aux.dt.check('" + XMLSchema.DATETIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no1," +
-                    "n10s.aux.dt.check('" + XMLSchema.DATE.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no2," +
-                    "n10s.aux.dt.check('" + XMLSchema.TIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no3");
-            assertTrue(res.hasNext());
-            record = res.next();
-            assertFalse(record.get("no0").asBoolean());
-            assertFalse(record.get("no1").asBoolean());
-            assertFalse(record.get("no2").asBoolean());
-            assertFalse(record.get("no3").asBoolean());
+        res = session.run("RETURN n10s.aux.dt.check('" + WKTLITERAL_URI.stringValue() + "',true) as no0," +
+                "n10s.aux.dt.check('" + XMLSchema.DATETIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no1," +
+                "n10s.aux.dt.check('" + XMLSchema.DATE.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no2," +
+                "n10s.aux.dt.check('" + XMLSchema.TIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no3");
+        assertTrue(res.hasNext());
+        record = res.next();
+        assertFalse(record.get("no0").asBoolean());
+        assertFalse(record.get("no1").asBoolean());
+        assertFalse(record.get("no2").asBoolean());
+        assertFalse(record.get("no3").asBoolean());
 
-            res = session.run("RETURN n10s.aux.dt.check('" + WKTLITERAL_URI.stringValue() + "',44.56) as no0," +
-                    "n10s.aux.dt.check('" + XMLSchema.DATETIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no1," +
-                    "n10s.aux.dt.check('" + XMLSchema.DATE.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no2," +
-                    "n10s.aux.dt.check('" + XMLSchema.TIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no3");
-            assertTrue(res.hasNext());
-            record = res.next();
-            assertFalse(record.get("no0").asBoolean());
-            assertFalse(record.get("no1").asBoolean());
-            assertFalse(record.get("no2").asBoolean());
-            assertFalse(record.get("no3").asBoolean());
+        res = session.run("RETURN n10s.aux.dt.check('" + WKTLITERAL_URI.stringValue() + "',44.56) as no0," +
+                "n10s.aux.dt.check('" + XMLSchema.DATETIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no1," +
+                "n10s.aux.dt.check('" + XMLSchema.DATE.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no2," +
+                "n10s.aux.dt.check('" + XMLSchema.TIME.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no3");
+        assertTrue(res.hasNext());
+        record = res.next();
+        assertFalse(record.get("no0").asBoolean());
+        assertFalse(record.get("no1").asBoolean());
+        assertFalse(record.get("no2").asBoolean());
+        assertFalse(record.get("no3").asBoolean());
 
-            res = session.run("RETURN n10s.aux.dt.check('" + XMLSchema.ANYURI.stringValue() + "',44.56) as no0," +
-                    "n10s.aux.dt.check('" + XMLSchema.ANYURI.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no1," +
-                    "n10s.aux.dt.check('" + XMLSchema.ANYURI.stringValue() + "','this is a string') as no2," +
-                    "n10s.aux.dt.check('" + XMLSchema.ANYURI.stringValue() + "','neo4j://home.voc/123#something') as yes");
-            assertTrue(res.hasNext());
-            record = res.next();
-            assertFalse(record.get("no0").asBoolean());
-            assertFalse(record.get("no1").asBoolean());
-            assertFalse(record.get("no2").asBoolean());
-            assertTrue(record.get("yes").asBoolean());
+        res = session.run("RETURN n10s.aux.dt.check('" + XMLSchema.ANYURI.stringValue() + "',44.56) as no0," +
+                "n10s.aux.dt.check('" + XMLSchema.ANYURI.stringValue() + "',point({x: -0.1275, y: 51.507222222})) as no1," +
+                "n10s.aux.dt.check('" + XMLSchema.ANYURI.stringValue() + "','this is a string') as no2," +
+                "n10s.aux.dt.check('" + XMLSchema.ANYURI.stringValue() + "','neo4j://home.voc/123#something') as yes");
+        assertTrue(res.hasNext());
+        record = res.next();
+        assertFalse(record.get("no0").asBoolean());
+        assertFalse(record.get("no1").asBoolean());
+        assertFalse(record.get("no2").asBoolean());
+        assertTrue(record.get("yes").asBoolean());
 
-            session.run("CREATE (:Thing { dt: date(), dtm: datetime(), zdt: datetime('1956-06-25T09:00:00[Europe/Berlin]')," +
-                    "theint: 45, thebo: false, flo: 4.567, po: point({x: -0.1275, y: 51.507222222, z: 44 }), " +
-                    "uri: 'mail://somet hing.io#123'})");
+        session.run("CREATE (:Thing { dt: date(), dtm: datetime(), zdt: datetime('1956-06-25T09:00:00[Europe/Berlin]')," +
+                "theint: 45, thebo: false, flo: 4.567, po: point({x: -0.1275, y: 51.507222222, z: 44 }), " +
+                "uri: 'mail://somet hing.io#123'})");
 
-            assertEquals(1L,session.run("MATCH (t:Thing) RETURN count(t) as thingcount").next().get("thingcount").asInt());
+        assertEquals(1L,session.run("MATCH (t:Thing) RETURN count(t) as thingcount").next().get("thingcount").asInt());
 
-            res = session.run("MATCH (t:Thing) RETURN n10s.aux.dt.check('" + WKTLITERAL_URI.stringValue() + "',t.zdt) as no1," +
-                    "n10s.aux.dt.check('" + XMLSchema.DATETIME.stringValue() + "',t.zdt) as yes," +
-                    "n10s.aux.dt.check('" + XMLSchema.DATE.stringValue() + "',t.zdt) as no2," +
-                    "n10s.aux.dt.check('" + XMLSchema.TIME.stringValue() + "',t.zdt) as no3," +
-                    "n10s.aux.dt.check('" + XMLSchema.ANYURI.stringValue() + "',t.uri) as no4");
-            assertTrue(res.hasNext());
-            record = res.next();
-            assertTrue(record.get("yes").asBoolean());
-            assertFalse(record.get("no1").asBoolean());
-            assertFalse(record.get("no2").asBoolean());
-            assertFalse(record.get("no3").asBoolean());
-            assertFalse(record.get("no4").asBoolean());
+        res = session.run("MATCH (t:Thing) RETURN n10s.aux.dt.check('" + WKTLITERAL_URI.stringValue() + "',t.zdt) as no1," +
+                "n10s.aux.dt.check('" + XMLSchema.DATETIME.stringValue() + "',t.zdt) as yes," +
+                "n10s.aux.dt.check('" + XMLSchema.DATE.stringValue() + "',t.zdt) as no2," +
+                "n10s.aux.dt.check('" + XMLSchema.TIME.stringValue() + "',t.zdt) as no3," +
+                "n10s.aux.dt.check('" + XMLSchema.ANYURI.stringValue() + "',t.uri) as no4");
+        assertTrue(res.hasNext());
+        record = res.next();
+        assertTrue(record.get("yes").asBoolean());
+        assertFalse(record.get("no1").asBoolean());
+        assertFalse(record.get("no2").asBoolean());
+        assertFalse(record.get("no3").asBoolean());
+        assertFalse(record.get("no4").asBoolean());
 
-
-        }
     }
 }

--- a/src/test/java/n10s/endpoint/RDFEndpointTest.java
+++ b/src/test/java/n10s/endpoint/RDFEndpointTest.java
@@ -1206,7 +1206,7 @@ public class RDFEndpointTest {
     }
 
     Map<String, Object> map = new HashMap<>();
-    map.put("cypher", "MATCH (n:Category)--(m:Category) RETURN n,m LIMIT 4");
+    map.put("cypher", "MATCH (n:Category)--(:Category) RETURN distinct n LIMIT 4");
 
     HTTP.Response response = HTTP.withHeaders("Accept", "text/plain").POST(
         HTTP.GET(neo4j.httpURI().resolve("rdf").toString()).location() + "neo4j/cypher", map);
@@ -2382,7 +2382,7 @@ public class RDFEndpointTest {
   public void testCypherOnQuadRDFSerializeAsTriG() throws Exception {
     final GraphDatabaseService graphDatabaseService = neo4j.defaultDatabaseService();
     try (Transaction tx = graphDatabaseService.beginTx()) {
-      tx.execute("CREATE INDEX ON :Resource(uri)");
+      tx.execute("create index for (n:Resource) on (n.uri)");
       tx.commit();
     }
     try (Transaction tx = graphDatabaseService.beginTx()) {
@@ -2419,7 +2419,7 @@ public class RDFEndpointTest {
   public void testCypherOnQuadRDFSerializeAsNQuads() throws Exception {
     final GraphDatabaseService graphDatabaseService = neo4j.defaultDatabaseService();
     try (Transaction tx = graphDatabaseService.beginTx()) {
-      tx.execute("CREATE INDEX ON :Resource(uri)");
+      tx.execute("create index for (n:Resource) on (n.uri)");
       tx.commit();
     }
     try (Transaction tx = graphDatabaseService.beginTx()) {
@@ -2456,7 +2456,7 @@ public class RDFEndpointTest {
   public void testNodeByUriOnQuadRDF() throws Exception {
     final GraphDatabaseService graphDatabaseService = neo4j.defaultDatabaseService();
     try (Transaction tx = graphDatabaseService.beginTx()) {
-      tx.execute("CREATE INDEX ON :Resource(uri)");
+      tx.execute("create index for (n:Resource) on (n.uri)");
       tx.commit();
     }
     try (Transaction tx = graphDatabaseService.beginTx()) {
@@ -2490,7 +2490,7 @@ public class RDFEndpointTest {
   public void testNodeByUriWithGraphUriOnQuadRDFTrig() throws Exception {
     final GraphDatabaseService graphDatabaseService = neo4j.defaultDatabaseService();
     try (Transaction tx = graphDatabaseService.beginTx()) {
-      tx.execute("CREATE INDEX ON :Resource(uri)");
+      tx.execute("create index for (n:Resource) on (n.uri)");
       tx.commit();
     }
     try (Transaction tx = graphDatabaseService.beginTx()) {
@@ -2531,7 +2531,7 @@ public class RDFEndpointTest {
   public void testNodeByUriWithGraphUriOnQuadRDFNQuads() throws Exception {
     final GraphDatabaseService graphDatabaseService = neo4j.defaultDatabaseService();
     try (Transaction tx = graphDatabaseService.beginTx()) {
-      tx.execute("CREATE INDEX ON :Resource(uri)");
+      tx.execute("create index for (n:Resource) on (n.uri)");
       tx.commit();
     }
     try (Transaction tx = graphDatabaseService.beginTx()) {
@@ -2570,7 +2570,7 @@ public class RDFEndpointTest {
     // Given
     final GraphDatabaseService graphDatabaseService = neo4j.defaultDatabaseService();
     try (Transaction tx = graphDatabaseService.beginTx()) {
-      tx.execute("CREATE INDEX ON :Resource(uri)");
+      tx.execute("create index for (n:Resource) on (n.uri)");
       tx.commit();
     }
     try (Transaction tx = graphDatabaseService.beginTx()) {
@@ -2639,7 +2639,7 @@ public class RDFEndpointTest {
     //  check data is  correctly loaded
     Long id;
     try (Transaction tx = graphDatabaseService.beginTx()) {
-      Result result = tx.execute("match (n:ConceptScheme) return properties(n) as n, size((n)--()) as deg");
+      Result result = tx.execute("match (n:ConceptScheme) return properties(n) as n, size([(n)-[r]-()| r]) as deg");
       Map<String, Object> next = result.next();
       Map<String,Object> n = (Map<String,Object>)next.get("n");
       long[] tcVals = (long[])n.get("topConcepts");

--- a/src/test/java/n10s/endpoint/RDFEndpointTest.java
+++ b/src/test/java/n10s/endpoint/RDFEndpointTest.java
@@ -1026,7 +1026,7 @@ public class RDFEndpointTest {
     }
     Long id = null;
     try (Transaction tx = graphDatabaseService.beginTx()) {
-      Result result = tx.execute("MATCH (n:Critic) RETURN id(n) AS id ");
+      Result result = tx.execute("MATCH (n:Director {name:'Laurence Fishburne'}) RETURN id(n) AS id ");
       id = (Long) result.next().get("id");
       assertNotNull(id);
     }

--- a/src/test/java/n10s/endpoint/RDFEndpointTest.java
+++ b/src/test/java/n10s/endpoint/RDFEndpointTest.java
@@ -114,7 +114,6 @@ public class RDFEndpointTest {
 
   @Test
   public void testGetNodeById() throws Exception {
-    // Given
     try (Transaction tx = graphDatabaseService.beginTx()) {
 
       String ontoCreation = "MERGE (p:Category {catName: ' Person'})\n" +
@@ -213,7 +212,6 @@ public class RDFEndpointTest {
 
   @Test
   public void testGetNodeByIdFromRDFizedLPG() throws Exception {
-    // Given
     try (Transaction tx = graphDatabaseService.beginTx()) {
 
       String configCreation = "CALL n10s.graphconfig.init({handleVocabUris:'IGNORE'}) ";
@@ -281,7 +279,6 @@ public class RDFEndpointTest {
 
   @Test
   public void testCypherCgnt() throws Exception {
-    // Given
 
     try (Transaction tx = graphDatabaseService.beginTx()) {
       tx.execute("UNWIND RANGE(1,5,1) as id\n" +
@@ -298,8 +295,18 @@ public class RDFEndpointTest {
       tx.commit();
     }
 
+    String cableid;
+    String crpid;
+    try (Transaction tx = graphDatabaseService.beginTx()) {
+      Result result = tx.execute("match (c:Cable{ id: 4 })--(crp:CableRoutingPoint{id: 2 }) " +
+              " return id(c) as cableid, id(crp) as crpid ");
+      Map<String, Object> record = result.next();
+      cableid = record.get("cableid").toString();
+      crpid = record.get("crpid").toString();
+    }
+
     Map<String, Object> map = new HashMap<>();
-    map.put("cypher", "MATCH s = ()--() RETURN s");
+    map.put("cypher", "MATCH s = (:Cable{id: 4 })--(:CableRoutingPoint{id: 2 }) RETURN s");
     map.put("format", "Turtle-star");
 
     Response response = HTTP.withHeaders("Accept", "text/plain").POST(
@@ -308,136 +315,21 @@ public class RDFEndpointTest {
     String expected = "@prefix n4sch: <neo4j://graph.schema#> .\n" +
             "@prefix n4ind: <neo4j://graph.individuals#> .\n" +
             "\n" +
-            "n4ind:3 a n4sch:CableRoutingPoint;\n" +
-            "  n4sch:id \"2\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
-            "  n4sch:inspectionDates \"2019-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>,\n" +
-            "    \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>, \"2020-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:typeCodes \"C\", \"B\", \"A\";\n" +
-            "  n4sch:location \"Point(-0.1275 51.507222222)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral> .\n" +
-            "\n" +
-            "n4ind:0 a n4sch:Cable;\n" +
-            "  n4sch:id \"1\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
-            "  n4sch:HAS_ROUTING_POINT n4ind:3, n4ind:1;\n" +
-            "  n4sch:createdAt \"2017-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:name \"cable_1\" .\n" +
-            "\n" +
-            "<<n4ind:0 n4sch:HAS_ROUTING_POINT n4ind:3>> n4sch:createdAt \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:labels \"bar\", \"foo\" .\n" +
-            "\n" +
-            "n4ind:1 a n4sch:CableRoutingPoint;\n" +
-            "  n4sch:id \"1\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
-            "  n4sch:inspectionDates \"2019-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>,\n" +
-            "    \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>, \"2020-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:location \"Point(-0.1275 51.507222222)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>;\n" +
-            "  n4sch:typeCodes \"A\", \"B\", \"C\" .\n" +
-            "\n" +
-            "<<n4ind:0 n4sch:HAS_ROUTING_POINT n4ind:1>> n4sch:labels \"bar\", \"foo\";\n" +
-            "  n4sch:createdAt \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n" +
-            "\n" +
-            "<<n4ind:2 n4sch:HAS_ROUTING_POINT n4ind:6>> n4sch:labels \"foo\", \"bar\";\n" +
-            "  n4sch:createdAt \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n" +
-            "\n" +
-            "n4ind:6 a n4sch:CableRoutingPoint;\n" +
-            "  n4sch:inspectionDates \"2019-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>,\n" +
-            "    \"2020-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>, \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:location \"Point(-0.1275 51.507222222)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>;\n" +
-            "  n4sch:typeCodes \"B\", \"A\", \"C\";\n" +
-            "  n4sch:id \"2\"^^<http://www.w3.org/2001/XMLSchema#long> .\n" +
-            "\n" +
-            "n4ind:2 a n4sch:Cable;\n" +
-            "  n4sch:id \"2\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
-            "  n4sch:createdAt \"2017-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:HAS_ROUTING_POINT n4ind:6, n4ind:4;\n" +
-            "  n4sch:name \"cable_2\" .\n" +
-            "\n" +
-            "n4ind:4 a n4sch:CableRoutingPoint;\n" +
-            "  n4sch:inspectionDates \"2019-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>,\n" +
-            "    \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>, \"2020-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:id \"1\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
-            "  n4sch:typeCodes \"C\", \"A\", \"B\";\n" +
-            "  n4sch:location \"Point(-0.1275 51.507222222)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral> .\n" +
-            "\n" +
-            "<<n4ind:2 n4sch:HAS_ROUTING_POINT n4ind:4>> n4sch:labels \"bar\", \"foo\";\n" +
-            "  n4sch:createdAt \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n" +
-            "\n" +
-            "n4ind:7 a n4sch:CableRoutingPoint;\n" +
-            "  n4sch:inspectionDates \"2019-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>,\n" +
-            "    \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>, \"2020-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:typeCodes \"A\", \"C\", \"B\";\n" +
-            "  n4sch:location \"Point(-0.1275 51.507222222)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral>;\n" +
-            "  n4sch:id \"1\"^^<http://www.w3.org/2001/XMLSchema#long> .\n" +
-            "\n" +
-            "<<n4ind:5 n4sch:HAS_ROUTING_POINT n4ind:7>> n4sch:labels \"foo\", \"bar\";\n" +
-            "  n4sch:createdAt \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n" +
-            "\n" +
-            "n4ind:5 a n4sch:Cable;\n" +
-            "  n4sch:createdAt \"2017-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:HAS_ROUTING_POINT n4ind:7, n4ind:9;\n" +
-            "  n4sch:id \"3\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
-            "  n4sch:name \"cable_3\" .\n" +
-            "\n" +
-            "<<n4ind:5 n4sch:HAS_ROUTING_POINT n4ind:9>> n4sch:labels \"foo\", \"bar\";\n" +
-            "  n4sch:createdAt \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n" +
-            "\n" +
-            "n4ind:9 a n4sch:CableRoutingPoint;\n" +
-            "  n4sch:inspectionDates \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>,\n" +
-            "    \"2019-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>, \"2020-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:id \"2\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
-            "  n4sch:typeCodes \"A\", \"B\", \"C\";\n" +
-            "  n4sch:location \"Point(-0.1275 51.507222222)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral> .\n" +
-            "\n" +
-            "n4ind:8 a n4sch:Cable;\n" +
+            "n4ind:" + cableid + " a n4sch:Cable;\n" +
             "  n4sch:name \"cable_4\";\n" +
             "  n4sch:createdAt \"2017-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
             "  n4sch:id \"4\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
-            "  n4sch:HAS_ROUTING_POINT n4ind:12, n4ind:10 .\n" +
+            "  n4sch:HAS_ROUTING_POINT n4ind:" + crpid + " .\n" +
             "\n" +
-            "n4ind:12 a n4sch:CableRoutingPoint;\n" +
+            "n4ind:" + crpid + " a n4sch:CableRoutingPoint;\n" +
             "  n4sch:inspectionDates \"2019-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>,\n" +
             "    \"2020-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>, \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
             "  n4sch:id \"2\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
             "  n4sch:typeCodes \"A\", \"B\", \"C\";\n" +
             "  n4sch:location \"Point(-0.1275 51.507222222)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral> .\n" +
-            "\n" +
-            "<<n4ind:8 n4sch:HAS_ROUTING_POINT n4ind:12>> n4sch:labels \"bar\", \"foo\";\n" +
+            "<<n4ind:" + cableid + " n4sch:HAS_ROUTING_POINT n4ind:" + crpid + ">> n4sch:labels \"bar\", \"foo\";\n" +
             "  n4sch:createdAt \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n" +
-            "\n" +
-            "n4ind:10 a n4sch:CableRoutingPoint;\n" +
-            "  n4sch:inspectionDates \"2019-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>,\n" +
-            "    \"2020-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>, \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:id \"1\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
-            "  n4sch:typeCodes \"A\", \"C\", \"B\";\n" +
-            "  n4sch:location \"Point(-0.1275 51.507222222)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral> .\n" +
-            "\n" +
-            "<<n4ind:8 n4sch:HAS_ROUTING_POINT n4ind:10>> n4sch:labels \"bar\", \"foo\";\n" +
-            "  n4sch:createdAt \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n" +
-            "\n" +
-            "n4ind:13 a n4sch:CableRoutingPoint;\n" +
-            "  n4sch:inspectionDates \"2019-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>,\n" +
-            "    \"2020-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>, \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:id \"1\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
-            "  n4sch:typeCodes \"A\", \"B\", \"C\";\n" +
-            "  n4sch:location \"Point(-0.1275 51.507222222)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral> .\n" +
-            "\n" +
-            "n4ind:11 a n4sch:Cable;\n" +
-            "  n4sch:id \"5\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
-            "  n4sch:HAS_ROUTING_POINT n4ind:13, n4ind:14;\n" +
-            "  n4sch:name \"cable_5\";\n" +
-            "  n4sch:createdAt \"2017-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n" +
-            "\n" +
-            "<<n4ind:11 n4sch:HAS_ROUTING_POINT n4ind:13>> n4sch:labels \"foo\", \"bar\";\n" +
-            "  n4sch:createdAt \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n" +
-            "\n" +
-            "n4ind:14 a n4sch:CableRoutingPoint;\n" +
-            "  n4sch:inspectionDates \"2019-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>,\n" +
-            "    \"2020-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>, \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime>;\n" +
-            "  n4sch:id \"2\"^^<http://www.w3.org/2001/XMLSchema#long>;\n" +
-            "  n4sch:typeCodes \"C\", \"B\", \"A\";\n" +
-            "  n4sch:location \"Point(-0.1275 51.507222222)\"^^<http://www.opengis.net/ont/geosparql#wktLiteral> .\n" +
-            "\n" +
-            "<<n4ind:11 n4sch:HAS_ROUTING_POINT n4ind:14>> n4sch:labels \"foo\", \"bar\";\n" +
-            "  n4sch:createdAt \"2018-04-05T12:34:00+02:00\"^^<http://www.w3.org/2001/XMLSchema#dateTime> .\n" +
-            "\n";
+            "\n" ;
 
     assertEquals(200, response.status());
     assertTrue(ModelTestUtils
@@ -447,7 +339,6 @@ public class RDFEndpointTest {
 
   @Test
   public void testCypherReturnsList() throws Exception {
-    // Given
 
     try (Transaction tx = graphDatabaseService.beginTx()) {
       tx.execute("call n10s.nsprefixes.add('sch','http://schema.org/')");
@@ -503,7 +394,6 @@ public class RDFEndpointTest {
 
   @Test
   public void testPrefixwithHyphen() throws Exception {
-    // Given
 
     //first import onto
     try (Transaction tx = graphDatabaseService.beginTx()) {
@@ -568,7 +458,6 @@ public class RDFEndpointTest {
 
   @Test
   public void testCypherOnMovieDBReturnsList() throws Exception {
-    // Given
 
     try (Transaction tx = graphDatabaseService.beginTx()) {
       tx.execute("call n10s.nsprefixes.add('sch','http://schema.org/')");
@@ -640,7 +529,6 @@ public class RDFEndpointTest {
 
   @Test
   public void testCypherReturnsListOnRDFGraph() throws Exception {
-    // Given
     try (Transaction tx = graphDatabaseService.beginTx()) {
       tx.execute(UNIQUENESS_CONSTRAINT_STATEMENT);
       tx.commit();
@@ -678,7 +566,6 @@ public class RDFEndpointTest {
 
   @Test
   public void testGetNodeByIdRDFStar() throws Exception {
-    // Given
     try (Transaction tx = graphDatabaseService.beginTx()) {
 
       String dataInsertion = "CREATE (Keanu:Actor {name:'Keanu Reeves', born:1964})\n" +
@@ -731,7 +618,6 @@ public class RDFEndpointTest {
 
   @Test
   public void ImportGetNodeById() throws Exception {
-    // Given
 
     try (Transaction tx = graphDatabaseService.beginTx()) {
       String ontoCreation = "MERGE (p:Category {catName: ' Person'})\n" +
@@ -794,7 +680,6 @@ public class RDFEndpointTest {
 
   @Test
   public void ImportGetNodeByIdOnImportedOnto() throws Exception {
-    // Given
 
     //first import onto
     try (Transaction tx = graphDatabaseService.beginTx()) {
@@ -843,7 +728,6 @@ public class RDFEndpointTest {
 
   @Test
   public void ImportGetNodeByUriOnImportedOntoShorten() throws Exception {
-    // Given
 
     //first import onto
     try (Transaction tx = graphDatabaseService.beginTx()) {
@@ -907,7 +791,6 @@ public class RDFEndpointTest {
 
   @Test
   public void ImportGetNodeByUriOnImportedOntoIgnore() throws Exception {
-    // Given
 
     //first import onto
     try (Transaction tx = graphDatabaseService.beginTx()) {
@@ -1218,7 +1101,6 @@ public class RDFEndpointTest {
 
   @Test
   public void testPing() throws Exception {
-    // Given
     HTTP.Response response = HTTP.GET(
         HTTP.GET(neo4j.httpURI().resolve("rdf").toString()).location() + "ping");
 
@@ -2603,7 +2485,6 @@ public class RDFEndpointTest {
 
   @Test
   public void testCypherOnQuadRDFAfterDeleteRDFBNodes() throws Exception {
-    // Given
     try (Transaction tx = graphDatabaseService.beginTx()) {
       tx.execute("CREATE INDEX uri_index FOR (r:Resource) ON (r.uri)");
       tx.commit();
@@ -2652,7 +2533,6 @@ public class RDFEndpointTest {
 
   @Test
   public void testTicket13061() throws Exception {
-    // Given
     //create constraint
     try (Transaction tx = graphDatabaseService.beginTx()) {
       tx.execute(UNIQUENESS_CONSTRAINT_STATEMENT);

--- a/src/test/java/n10s/graphconfig/GraphConfigProceduresTest.java
+++ b/src/test/java/n10s/graphconfig/GraphConfigProceduresTest.java
@@ -6,22 +6,33 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import n10s.rdf.load.RDFLoadProcedures;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
+import org.junit.jupiter.api.BeforeEach;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.*;
 import org.neo4j.harness.junit.rule.Neo4jRule;
 
 public class GraphConfigProceduresTest {
+      public static Driver driver;
 
-  @Rule
-  public Neo4jRule neo4j = new Neo4jRule()
-      .withProcedure(GraphConfigProcedures.class).withProcedure(RDFLoadProcedures.class);
+      @ClassRule
+      public static Neo4jRule neo4j = new Neo4jRule()
+              .withProcedure(GraphConfigProcedures.class).withProcedure(RDFLoadProcedures.class);
+
+      @BeforeClass
+      public static void init() {
+          driver = GraphDatabase.driver(neo4j.boltURI(),
+                Config.builder().withoutEncryption().build());
+      }
+
+      @Before
+      public void cleanDatabase() {
+          driver.session().run("match (n) detach delete n").consume();
+          driver.session().run("drop constraint n10s_unique_uri if exists");
+      }
 
   @Test
   public void testInitGraphConfig() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
 
       Session session = driver.session();
 
@@ -66,15 +77,10 @@ public class GraphConfigProceduresTest {
               + " with param, value where param = 'baseSchemaNamespace' return param, value ");
       assertEquals(true, results.hasNext());
       assertEquals("http://base#", results.next().get("value").asString());
-
-    }
   }
 
   @Test
   public void testModifyGraphConfigWhenDataInGraph() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       session.run(UNIQUENESS_CONSTRAINT_STATEMENT);
@@ -95,16 +101,10 @@ public class GraphConfigProceduresTest {
         assertTrue(e.getMessage().contains("n10s.graphconfig.GraphConfigProcedures$"
             + "GraphConfigException: The graph is non-empty. Config cannot be changed."));
       }
-
-
-    }
   }
 
   @Test
   public void testForceModifyGraphConfigWhenDataInGraph() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       session.run(UNIQUENESS_CONSTRAINT_STATEMENT);
@@ -136,18 +136,11 @@ public class GraphConfigProceduresTest {
         if(paramVal.get("param").equals("handleMultival")){
           assertEquals("ARRAY",paramVal.get("value"));
         }
-      }
-
-
-
     }
   }
 
   @Test
   public void testDropGraph() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       Result results = session.run("CALL n10s.graphconfig.init() yield param, value "
@@ -158,8 +151,5 @@ public class GraphConfigProceduresTest {
 
       results = session.run("MATCH (gc:_GraphConfig) return gc");
       assertFalse(results.hasNext());
-
-
-    }
   }
 }

--- a/src/test/java/n10s/graphconfig/GraphConfigProceduresTest.java
+++ b/src/test/java/n10s/graphconfig/GraphConfigProceduresTest.java
@@ -28,7 +28,7 @@ public class GraphConfigProceduresTest {
       @Before
       public void cleanDatabase() {
           driver.session().run("match (n) detach delete n").consume();
-          driver.session().run("drop constraint n10s_unique_uri if exists");
+          driver.session().run("drop constraint n10s_unique_uri if exists").consume();
       }
 
   @Test

--- a/src/test/java/n10s/mapping/MappingUtilsTest.java
+++ b/src/test/java/n10s/mapping/MappingUtilsTest.java
@@ -6,29 +6,44 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import n10s.graphconfig.GraphConfigProcedures;
 import n10s.nsprefixes.NsPrefixDefProcedures;
-import org.junit.Rule;
-import org.junit.Test;
+import n10s.rdf.load.AddProcedures;
+import n10s.rdf.load.RDFLoadProcedures;
+import org.junit.*;
 import org.neo4j.driver.*;
 import org.neo4j.driver.Record;
 import org.neo4j.harness.junit.rule.Neo4jRule;
 
 public class MappingUtilsTest {
+  public static Driver driver;
 
-  @Rule
-  public Neo4jRule neo4j = new Neo4jRule()
-      .withProcedure(MappingUtils.class).withFunction(MappingUtils.class)
-      .withProcedure(NsPrefixDefProcedures.class);
+  @ClassRule
+  public static Neo4jRule neo4j = new Neo4jRule()
+          .withProcedure(MappingUtils.class)
+          .withFunction(MappingUtils.class)
+          .withProcedure(NsPrefixDefProcedures.class);
+
+  @BeforeClass
+  public static void init() {
+    driver = GraphDatabase.driver(neo4j.boltURI(),
+            Config.builder().withoutEncryption().build());
+  }
+
+  @Before
+  public void cleanDatabase() {
+    driver.session().run("match (n) detach delete n").consume();
+    driver.session().run("drop constraint n10s_unique_uri if exists").consume();
+  }
 
 
   @Test
   public void testaddSchema() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session();) {
+    try (Session session = driver.session()) {
       assertTrue(session.run(" call n10s.nsprefixes.add(\"v1\",\"http://vocabularies.com/vocabulary1/\")").hasNext());
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session();) {
+    try (Session session = driver.session();) {
 
       Map<String, Object> params = new HashMap<>();
       params.put("vocElem", "http://voc.new/sch1#something");
@@ -46,13 +61,9 @@ public class MappingUtilsTest {
 
   @Test
   public void testAddMappingToSchema() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session();) {
+    try (Session session = driver.session();) {
       assertTrue(session.run(" call n10s.nsprefixes.add(\"sch1\",\"http://schemas.com/schema1/\")").hasNext());
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       // when DB is empty
@@ -88,17 +99,14 @@ public class MappingUtilsTest {
       assertTrue(session.run(existMappingAndNs, params).hasNext());
       params.put("vocElem", nameInVoc);
       assertFalse(session.run(existMappingAndNs, params).hasNext());
-    }
   }
 
   @Test
   public void testListMappings() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session();) {
+    try (Session session = driver.session();) {
       assertTrue(session.run(" call n10s.nsprefixes.add(\"sch\",\"http://schema.org/\")").hasNext());
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build());  Session session = driver.session();) {
+    Session session = driver.session();
 
       // when DB is empty
       assertFalse(session.run("MATCH (n) WHERE not n:_NsPrefDef RETURN n").hasNext());
@@ -113,18 +121,13 @@ public class MappingUtilsTest {
       assertEquals(1, session.run(
           "CALL n10s.mapping.list('Person') yield elemName RETURN count(elemName) as ct ")
           .next().get("ct").asInt());
-    }
   }
 
   @Test
   public void testDropMappings() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session();) {
+    try (Session session = driver.session();) {
       assertTrue(session.run(" call n10s.nsprefixes.add(\"sch\",\"http://schema.org/\")").hasNext());
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       // when DB is empty
@@ -140,19 +143,13 @@ public class MappingUtilsTest {
       assertEquals(2, session
           .run("CALL n10s.mapping.list() yield elemName RETURN count(elemName) as ct ")
           .next().get("ct").asInt());
-
-    }
   }
 
   @Test
   public void testDropMappingsAndSchemas() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session();) {
+    try (Session session = driver.session();) {
       assertTrue(session.run(" call n10s.nsprefixes.add(\"sch1\",\"http://schemas.com/schema1/\")").hasNext());
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       // when DB is empty
@@ -189,14 +186,11 @@ public class MappingUtilsTest {
       assertEquals(0, session
           .run("CALL n10s.mapping.list() yield elemName RETURN count(elemName) as ct ")
           .next().get("ct").asInt());
-
-    }
   }
 
   @Test
   public void testBug12931() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session();) {
+    Session session = driver.session();
       String step1 = "CALL n10s.nsprefixes.add(\"a\",\"neo4j://vocs/a/\")";
       String step2 = "CALL n10s.mapping.add(\"neo4j://vocs/a/something\",\"something\")";
       String step3 = "CALL n10s.mapping.add(\"neo4j://vocs/a/other\",\"other\")";
@@ -213,6 +207,4 @@ public class MappingUtilsTest {
               "return count(*) as namespacecount").next().get("namespacecount").asLong());
 
     }
-
-  }
 }

--- a/src/test/java/n10s/validation/SHACLValidationProceduresTest.java
+++ b/src/test/java/n10s/validation/SHACLValidationProceduresTest.java
@@ -15,12 +15,13 @@ import java.util.*;
 import n10s.aux.AuxProcedures;
 import n10s.graphconfig.GraphConfigProcedures;
 import n10s.nsprefixes.NsPrefixDefProcedures;
+import n10s.onto.load.OntoLoadProcedures;
+import n10s.onto.preview.OntoPreviewProcedures;
 import n10s.rdf.RDFProcedures;
 import n10s.rdf.load.RDFLoadProcedures;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.SHACL;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.neo4j.driver.*;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.types.Node;
@@ -64,18 +65,33 @@ public class SHACLValidationProceduresTest {
           + "       toString(([(vr)-[:`http://www.w3.org/ns/shacl#value`]->(x)| x.uri] + ([] + coalesce(vr.`http://www.w3.org/ns/shacl#value`,[])))[0]) as offendingValue, "
           + "      vr.`http://www.w3.org/ns/shacl#resultMessage` as message";
 
-  @Rule
-  public Neo4jRule neo4j = new Neo4jRule()
-      .withProcedure(ValidationProcedures.class).withProcedure(GraphConfigProcedures.class)
-      .withProcedure(RDFLoadProcedures.class).withFunction(RDFProcedures.class).withProcedure(
-          NsPrefixDefProcedures.class).withFunction(AuxProcedures.class);
+  public static Driver driver;
 
+  @ClassRule
+  public static Neo4jRule neo4j = new Neo4jRule()
+          .withProcedure(ValidationProcedures.class)
+          .withProcedure(GraphConfigProcedures.class)
+          .withProcedure(RDFLoadProcedures.class)
+          .withFunction(RDFProcedures.class)
+          .withProcedure(NsPrefixDefProcedures.class)
+          .withFunction(AuxProcedures.class);
+
+  @BeforeClass
+  public static void init() {
+    driver = GraphDatabase.driver(neo4j.boltURI(),
+            Config.builder().withoutEncryption().build());
+  }
+
+  @Before
+  public void cleanDatabase() {
+    driver.session().run("match (n) detach delete n").consume();
+    driver.session().run("drop constraint n10s_unique_uri if exists").consume();
+  }
+
+  final String CREATE_N10S_CONSTRAINT = "CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE (resource.uri) IS UNIQUE";
 
   @Test
   public void testCompiledValidatorIsPersisted() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
@@ -151,15 +167,11 @@ public class SHACLValidationProceduresTest {
 
       Result loadCompiled = session.run("call n10s.validation.shacl.validate()");
       assertTrue(loadCompiled.hasNext());
-    }
   }
 
 
   @Test
   public void testUriWithWhitespaces() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       String SHACL_URI_WHITESPACES = "@prefix neo4j: <neo4j://graph.schema#> .\n" +
@@ -190,14 +202,10 @@ public class SHACLValidationProceduresTest {
       List<Object> targetClasses = results.next().get("t").asList();
       assertTrue(targetClasses.size()==1);
       assertEquals("Soccer Player", targetClasses.get(0));
-    }
   }
 
   @Test
   public void testLargeShapesFile() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
@@ -238,7 +246,6 @@ public class SHACLValidationProceduresTest {
       }
       assertEquals(3, minCountCount);
       assertEquals(3, datatypeConstCount);
-    }
   }
 
   String SHAPES_CLOSED_NO_EXCLUSION = "@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n" +
@@ -297,17 +304,15 @@ public class SHACLValidationProceduresTest {
 
   @Test
   public void testClosedShapeIgnore() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE ");
+      session.run(CREATE_N10S_CONSTRAINT);
       session.run("call n10s.graphconfig.init({handleRDFTypes:\"LABELS_AND_NODES\",handleMultival:\"ARRAY\"});\n");
       session.run("call n10s.nsprefixes.add(\"ex\", \"http://www.example.com/device#\");");
       session.run("CALL n10s.rdf.import.inline('" + SHAPES_CLOSED_DATA + "',\"RDF/XML\")");
 
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       Result results = session
               .run("CALL n10s.validation.shacl.import.inline(\"" + SHAPES_CLOSED_NO_EXCLUSION + "\",\"Turtle\")");
@@ -321,17 +326,15 @@ public class SHACLValidationProceduresTest {
 
   @Test
   public void testClosedShapeNoExclusion() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
+      session.run(CREATE_N10S_CONSTRAINT);
       session.run("call n10s.graphconfig.init({handleRDFTypes:\"LABELS_AND_NODES\",handleMultival:\"ARRAY\"});\n");
       session.run("call n10s.nsprefixes.add(\"ex\", \"http://www.example.com/device#\");");
       session.run("CALL n10s.rdf.import.inline('" + SHAPES_CLOSED_DATA + "',\"RDF/XML\")");
 
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       Result results = session
               .run("CALL n10s.validation.shacl.import.inline(\"" + SHAPES_CLOSED_NO_EXCLUSION + "\",\"Turtle\")");
@@ -374,18 +377,16 @@ public class SHACLValidationProceduresTest {
 
   @Test
   public void testDataTypeShape() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
+      session.run(CREATE_N10S_CONSTRAINT);
       session.run("CALL n10s.graphconfig.init()");
       session.run("call n10s.nsprefixes.add(\"o1\",\"http://adaptive.accenture.com/ontologies/o1#\")");
       session.run("call n10s.nsprefixes.add(\"ind\",\"http://adaptive.accenture.com/ind#\")");
       session.run("CALL n10s.rdf.import.inline('" + DATE_DATA_1 + "',\"N-Triples\")");
 
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       Result results = session
               .run("CALL n10s.validation.shacl.import.inline(\"" + DATE_TYPE_CONSTRAINT + "\",\"Turtle\", {})");
@@ -431,18 +432,16 @@ public class SHACLValidationProceduresTest {
 
   @Test
   public void testDataTypeShapeDataTypeRestrictedPropUsedAsRel() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
+      session.run(CREATE_N10S_CONSTRAINT);
       session.run("CALL n10s.graphconfig.init()");
       session.run("call n10s.nsprefixes.add(\"o1\",\"http://adaptive.accenture.com/ontologies/o1#\")");
       session.run("call n10s.nsprefixes.add(\"ind\",\"http://adaptive.accenture.com/ind#\")");
       session.run("CALL n10s.rdf.import.inline('" + DATE_DATA_WHERE_PROP_IS_USED_AS_REL + "',\"N-Triples\")");
 
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       Result results = session
               .run("CALL n10s.validation.shacl.import.inline(\"" + DATE_TYPE_CONSTRAINT + "\",\"Turtle\", {})");
@@ -507,18 +506,16 @@ public class SHACLValidationProceduresTest {
 
   @Test
   public void testDataTypeShapeDataPointAndDate() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
+      session.run(CREATE_N10S_CONSTRAINT);
       session.run("CALL n10s.graphconfig.init()");
       session.run("call n10s.nsprefixes.add(\"o1\",\"http://adaptive.accenture.com/ontologies/o1#\")");
       session.run("call n10s.nsprefixes.add(\"ind\",\"http://adaptive.accenture.com/ind#\")");
       session.run("CALL n10s.rdf.import.inline('" + DATE_DATA_POINT_AND_TYPE + "',\"N-Triples\")");
 
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
 
       Result results = session
@@ -588,18 +585,16 @@ public class SHACLValidationProceduresTest {
 
   @Test
   public void testDataTypeShapeAnyUri() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
+      session.run(CREATE_N10S_CONSTRAINT);
       session.run("CALL n10s.graphconfig.init()");
       session.run("call n10s.nsprefixes.add(\"o1\",\"http://adaptive.accenture.com/ontologies/o1#\")");
       session.run("call n10s.nsprefixes.add(\"ind\",\"http://adaptive.accenture.com/ind#\")");
       session.run("CALL n10s.rdf.import.inline('" + DATE_DATA_ANYURI + "',\"N-Triples\")");
 
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
 
       Result results = session
@@ -637,18 +632,16 @@ public class SHACLValidationProceduresTest {
 
   @Test
   public void testMusicExample() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
+      session.run(CREATE_N10S_CONSTRAINT);
       session.run("CALL n10s.graphconfig.init( { handleMultival: 'ARRAY', "
           + "multivalPropList: [ 'http://stardog.com/tutorial/date'] })");
       session.run("CALL n10s.nsprefixes.add('tut','http://stardog.com/tutorial/')");
       session.close();
     }
 
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-          Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       Result loadShapes = session.run(
           "CALL n10s.validation.shacl.import.fetch(\"" + SHACLValidationProceduresTest.class
@@ -701,9 +694,6 @@ public class SHACLValidationProceduresTest {
 
   @Test
   public void testRegexValidationOnMovieDB() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
@@ -723,7 +713,7 @@ public class SHACLValidationProceduresTest {
               "  (RosieO)-[:ACTED_IN {roles:['Becky']}]->(SleeplessInSeattle),\n" +
               "  (NoraE)-[:DIRECTED]->(SleeplessInSeattle) ");
 
-      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
+      session.run(CREATE_N10S_CONSTRAINT);
 
       session.run("CALL n10s.validation.shacl.import.fetch(\"" + SHACLValidationProceduresTest.class
           .getClassLoader()
@@ -746,15 +736,10 @@ public class SHACLValidationProceduresTest {
               next.get("propertyShape").asString());
         }
       }
-
-    }
   }
 
   @Test
   public void testBug213() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
@@ -811,21 +796,14 @@ public class SHACLValidationProceduresTest {
               next.get("resultMessage").asString());
 
       assertEquals(false, validationResults.hasNext());
-
-    }
-
-
   }
 
     @Test
     public void testValidationBeforeNsDefined() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
+      session.run(CREATE_N10S_CONSTRAINT);
       session.run("CALL n10s.graphconfig.init()");
       Result result = session.run(
           "CALL n10s.validation.shacl.import.fetch(\"" + SHACLValidationProceduresTest.class
@@ -847,14 +825,10 @@ public class SHACLValidationProceduresTest {
               .getResource("shacl/person2-shacl.ttl")
               .toURI() + "\",\"Turtle\", {})");
       assertTrue(result.hasNext());
-    }
   }
 
   @Test
   public void testLoadShapesOutput() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
@@ -898,7 +872,7 @@ public class SHACLValidationProceduresTest {
       session.run("MATCH (n) DETACH DELETE n");
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
       //RDF SHORTEN GRAPH
-      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
+      session.run(CREATE_N10S_CONSTRAINT);
       session.run("CALL n10s.graphconfig.init()");
       session.run("CALL n10s.nsprefixes.add('neo','neo4j://graph.schema#')");
       session.run("CALL n10s.nsprefixes.add('ex','http://example/')");
@@ -1017,19 +991,14 @@ public class SHACLValidationProceduresTest {
         }
       }
       assertEquals(4, matches);
-    }
   }
 
   @Test
   public void testListAndDropShapesInRDFIgnoreGraph() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       session.run("CALL n10s.graphconfig.init({ handleVocabUris: 'IGNORE' })");
-
-      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
+      session.run(CREATE_N10S_CONSTRAINT);
 
       session.run("CALL n10s.validation.shacl.import.fetch(\"" + SHACLValidationProceduresTest.class
           .getClassLoader()
@@ -1076,21 +1045,15 @@ public class SHACLValidationProceduresTest {
         //Expected
         assertTrue(e.getMessage().contains("n10s.validation.SHACLValidationException: No shapes compiled"));
       }
-
-
-    }
   }
 
   @Test
   public void testListShapesInRDFShortenGraph() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       session.run("CALL n10s.graphconfig.init()");
-
-      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
+      
+      session.run(CREATE_N10S_CONSTRAINT);
 
       String turtleNsDefinition = "@prefix ex: <http://example/> .\n"
           + "@prefix neo4j: <neo4j://graph.schema#> .\n"
@@ -1145,16 +1108,10 @@ public class SHACLValidationProceduresTest {
         //Expected
         assertTrue(e.getMessage().contains("n10s.validation.SHACLValidationException: No shapes compiled"));
       }
-
-
-    }
   }
   
   @Test
   public void testTxTriggerValidation() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
@@ -1198,8 +1155,6 @@ public class SHACLValidationProceduresTest {
         //This is expected
         assertTrue(e.getMessage().contains("SHACLValidationException"));
       }
-
-    }
   }
 
 
@@ -1474,8 +1429,6 @@ public class SHACLValidationProceduresTest {
 
   public void runIndividualTest(String testGroupName, String testName,
       String cypherScript, String handleVocabUris, String ... overrideShapesFileName) throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-        Config.builder().withoutEncryption().build())) {
 
       Session session = driver.session();
       Result getschemastatementsResults = session
@@ -1634,12 +1587,6 @@ public class SHACLValidationProceduresTest {
       }
 
       session.run("MATCH (n) DETACH DELETE n ").hasNext();
-
-    } catch (Exception e) {
-      assertTrue("Failure due to exception raised: " + e.getMessage(), false);
-    }
-
-
   }
 
   private String selectQuery(String handleVocabUris) {
@@ -1656,9 +1603,6 @@ public class SHACLValidationProceduresTest {
 
   @Test
   public void testHasTypeValidationOnMovieDB() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build())) {
-
       Session session = driver.session();
 
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
@@ -1746,7 +1690,6 @@ public class SHACLValidationProceduresTest {
         }
       }
       assertEquals(2,count);
-    }
   }
 
   String SHAPES_REQUIRED_EXCLUDED_TYPES = "@prefix ex: <http://example.neo4j.com/graphvalidation#> .\n" +
@@ -1796,14 +1739,12 @@ public class SHACLValidationProceduresTest {
 
   @Test
   public void testRequiredAndExcludedTypes() throws Exception {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
       session.run("create (:Man { name: 'JB'}) ");
       session.run("create (:Person:Woman:Man { name: 'Carol'}) ");
     }
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       Result results = session
               .run("CALL n10s.validation.shacl.import.inline('" + SHAPES_REQUIRED_EXCLUDED_TYPES + "',\"Turtle\")");
@@ -1886,8 +1827,7 @@ public class SHACLValidationProceduresTest {
   }
 
   private void verifyBadCypher(String query) {
-    try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
-            Config.builder().withoutEncryption().build()); Session session = driver.session()) {
+    try (Session session = driver.session()) {
 
       Result results = session
               .run("CALL n10s.validation.shacl.import.inline('" + query + "',\"Turtle\")");

--- a/src/test/java/n10s/validation/SHACLValidationProceduresTest.java
+++ b/src/test/java/n10s/validation/SHACLValidationProceduresTest.java
@@ -300,7 +300,7 @@ public class SHACLValidationProceduresTest {
     try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
             Config.builder().withoutEncryption().build()); Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT ON ( resource:Resource ) ASSERT (resource.uri) IS UNIQUE ");
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE ");
       session.run("call n10s.graphconfig.init({handleRDFTypes:\"LABELS_AND_NODES\",handleMultival:\"ARRAY\"});\n");
       session.run("call n10s.nsprefixes.add(\"ex\", \"http://www.example.com/device#\");");
       session.run("CALL n10s.rdf.import.inline('" + SHAPES_CLOSED_DATA + "',\"RDF/XML\")");
@@ -324,7 +324,7 @@ public class SHACLValidationProceduresTest {
     try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
             Config.builder().withoutEncryption().build()); Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT ON ( resource:Resource ) ASSERT (resource.uri) IS UNIQUE ");
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
       session.run("call n10s.graphconfig.init({handleRDFTypes:\"LABELS_AND_NODES\",handleMultival:\"ARRAY\"});\n");
       session.run("call n10s.nsprefixes.add(\"ex\", \"http://www.example.com/device#\");");
       session.run("CALL n10s.rdf.import.inline('" + SHAPES_CLOSED_DATA + "',\"RDF/XML\")");
@@ -377,7 +377,7 @@ public class SHACLValidationProceduresTest {
     try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
             Config.builder().withoutEncryption().build()); Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT ON ( resource:Resource ) ASSERT (resource.uri) IS UNIQUE ");
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
       session.run("CALL n10s.graphconfig.init()");
       session.run("call n10s.nsprefixes.add(\"o1\",\"http://adaptive.accenture.com/ontologies/o1#\")");
       session.run("call n10s.nsprefixes.add(\"ind\",\"http://adaptive.accenture.com/ind#\")");
@@ -434,7 +434,7 @@ public class SHACLValidationProceduresTest {
     try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
             Config.builder().withoutEncryption().build()); Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT ON ( resource:Resource ) ASSERT (resource.uri) IS UNIQUE ");
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
       session.run("CALL n10s.graphconfig.init()");
       session.run("call n10s.nsprefixes.add(\"o1\",\"http://adaptive.accenture.com/ontologies/o1#\")");
       session.run("call n10s.nsprefixes.add(\"ind\",\"http://adaptive.accenture.com/ind#\")");
@@ -510,7 +510,7 @@ public class SHACLValidationProceduresTest {
     try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
             Config.builder().withoutEncryption().build()); Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT ON ( resource:Resource ) ASSERT (resource.uri) IS UNIQUE ");
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
       session.run("CALL n10s.graphconfig.init()");
       session.run("call n10s.nsprefixes.add(\"o1\",\"http://adaptive.accenture.com/ontologies/o1#\")");
       session.run("call n10s.nsprefixes.add(\"ind\",\"http://adaptive.accenture.com/ind#\")");
@@ -591,7 +591,7 @@ public class SHACLValidationProceduresTest {
     try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
             Config.builder().withoutEncryption().build()); Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT ON ( resource:Resource ) ASSERT (resource.uri) IS UNIQUE ");
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
       session.run("CALL n10s.graphconfig.init()");
       session.run("call n10s.nsprefixes.add(\"o1\",\"http://adaptive.accenture.com/ontologies/o1#\")");
       session.run("call n10s.nsprefixes.add(\"ind\",\"http://adaptive.accenture.com/ind#\")");
@@ -640,7 +640,7 @@ public class SHACLValidationProceduresTest {
     try (Driver driver = GraphDatabase.driver(neo4j.boltURI(),
         Config.builder().withoutEncryption().build()); Session session = driver.session()) {
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT ON ( resource:Resource ) ASSERT (resource.uri) IS UNIQUE ");
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
       session.run("CALL n10s.graphconfig.init( { handleMultival: 'ARRAY', "
           + "multivalPropList: [ 'http://stardog.com/tutorial/date'] })");
       session.run("CALL n10s.nsprefixes.add('tut','http://stardog.com/tutorial/')");
@@ -723,7 +723,7 @@ public class SHACLValidationProceduresTest {
               "  (RosieO)-[:ACTED_IN {roles:['Becky']}]->(SleeplessInSeattle),\n" +
               "  (NoraE)-[:DIRECTED]->(SleeplessInSeattle) ");
 
-      session.run("CREATE CONSTRAINT ON ( resource:Resource ) ASSERT (resource.uri) IS UNIQUE ");
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
 
       session.run("CALL n10s.validation.shacl.import.fetch(\"" + SHACLValidationProceduresTest.class
           .getClassLoader()
@@ -825,7 +825,7 @@ public class SHACLValidationProceduresTest {
       Session session = driver.session();
 
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
-      session.run("CREATE CONSTRAINT ON ( resource:Resource ) ASSERT (resource.uri) IS UNIQUE ");
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
       session.run("CALL n10s.graphconfig.init()");
       Result result = session.run(
           "CALL n10s.validation.shacl.import.fetch(\"" + SHACLValidationProceduresTest.class
@@ -898,7 +898,7 @@ public class SHACLValidationProceduresTest {
       session.run("MATCH (n) DETACH DELETE n");
       assertFalse(session.run("MATCH (n) RETURN n").hasNext());
       //RDF SHORTEN GRAPH
-      session.run("CREATE CONSTRAINT ON ( resource:Resource ) ASSERT (resource.uri) IS UNIQUE ");
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
       session.run("CALL n10s.graphconfig.init()");
       session.run("CALL n10s.nsprefixes.add('neo','neo4j://graph.schema#')");
       session.run("CALL n10s.nsprefixes.add('ex','http://example/')");
@@ -1029,7 +1029,7 @@ public class SHACLValidationProceduresTest {
 
       session.run("CALL n10s.graphconfig.init({ handleVocabUris: 'IGNORE' })");
 
-      session.run("CREATE CONSTRAINT ON ( resource:Resource ) ASSERT (resource.uri) IS UNIQUE ");
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
 
       session.run("CALL n10s.validation.shacl.import.fetch(\"" + SHACLValidationProceduresTest.class
           .getClassLoader()
@@ -1090,7 +1090,7 @@ public class SHACLValidationProceduresTest {
 
       session.run("CALL n10s.graphconfig.init()");
 
-      session.run("CREATE CONSTRAINT ON ( resource:Resource ) ASSERT (resource.uri) IS UNIQUE ");
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR ( resource:Resource ) REQUIRE resource.uri IS UNIQUE  ");
 
       String turtleNsDefinition = "@prefix ex: <http://example/> .\n"
           + "@prefix neo4j: <neo4j://graph.schema#> .\n"
@@ -1175,7 +1175,7 @@ public class SHACLValidationProceduresTest {
               "  (NoraE)-[:DIRECTED]->(SleeplessInSeattle) ");
 
       session.run(UNIQUENESS_CONSTRAINT_STATEMENT);
-      assertTrue(session.run("call db.schemaStatements").hasNext());
+      assertTrue(session.run("show unique constraints yield name").hasNext());
 
       Result loadShapesResult = session.run(
           "CALL n10s.validation.shacl.import.fetch(\"" + SHACLValidationProceduresTest.class
@@ -1479,14 +1479,14 @@ public class SHACLValidationProceduresTest {
 
       Session session = driver.session();
       Result getschemastatementsResults = session
-          .run("call db.schemaStatements() yield name return name");
+          .run("show unique constraints yield name");
       if (getschemastatementsResults.hasNext() &&
           getschemastatementsResults.next().get("name").asString()
               .equals(UNIQUENESS_CONSTRAINT_ON_URI)) {
         //constraint exists. do nothing.
       } else {
         session.run(UNIQUENESS_CONSTRAINT_STATEMENT);
-        assertTrue(session.run("call db.schemaStatements").hasNext());
+        assertTrue(session.run("show unique constraints yield name").hasNext());
       }
 
       //db is empty

--- a/src/test/resources/shacl/w3ctestsuite/core/property/count-query-001-keep-shapes.ttl
+++ b/src/test/resources/shacl/w3ctestsuite/core/property/count-query-001-keep-shapes.ttl
@@ -12,7 +12,7 @@
 ex:PersonShape
   rdf:type sh:NodeShape ;
   sh:property ex:PersonShape-pob ;
-  sh:targetQuery " exists (focus.`neo4j://graph.schema#hasPob`)  " ;
+  sh:targetQuery " focus.`neo4j://graph.schema#hasPob` is not null  " ;
 .
 
 ex:PersonShape-pob

--- a/src/test/resources/shacl/w3ctestsuite/core/property/count-query-001-shapes.ttl
+++ b/src/test/resources/shacl/w3ctestsuite/core/property/count-query-001-shapes.ttl
@@ -12,7 +12,7 @@
 ex:PersonShape
   rdf:type sh:NodeShape ;
   sh:property ex:PersonShape-pob ;
-  sh:targetQuery " exists (focus.hasPob)  " ;
+  sh:targetQuery " focus.hasPob is not null  " ;
 .
 
 ex:PersonShape-pob

--- a/src/test/resources/shacl/w3ctestsuite/core/property/count-query-001-shorten-shapes.ttl
+++ b/src/test/resources/shacl/w3ctestsuite/core/property/count-query-001-shorten-shapes.ttl
@@ -12,7 +12,7 @@
 ex:PersonShape
   rdf:type sh:NodeShape ;
   sh:property ex:PersonShape-pob ;
-  sh:targetQuery " exists (focus.ns0__hasPob)  " ;
+  sh:targetQuery " focus.ns0__hasPob is not null  " ;
 .
 
 ex:PersonShape-pob

--- a/src/test/resources/shacl/w3ctestsuite/core/property/in-query-001c-keep-shapes.ttl
+++ b/src/test/resources/shacl/w3ctestsuite/core/property/in-query-001c-keep-shapes.ttl
@@ -10,7 +10,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 neo:ShapeClass
-  sh:targetQuery " size((focus)-[:`neo4j://graph.schema#rel`]-()) > 3 " ;
+  sh:targetQuery " size([(focus)-[r:`neo4j://graph.schema#rel`]-() | id(r)]) > 3 " ;
   rdf:type sh:NodeShape ;
   sh:property ex:ShapeClass-property ;
 .

--- a/src/test/resources/shacl/w3ctestsuite/core/property/in-query-001c-shapes.ttl
+++ b/src/test/resources/shacl/w3ctestsuite/core/property/in-query-001c-shapes.ttl
@@ -10,7 +10,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 neo:ShapeClass
-  sh:targetQuery " size((focus)-[:rel]-()) > 3 " ;
+  sh:targetQuery " size([(focus)-[r:rel]-() | id(r)]) > 3 " ;
   rdf:type sh:NodeShape ;
   sh:property ex:ShapeClass-property ;
 .

--- a/src/test/resources/shacl/w3ctestsuite/core/property/in-query-001c-shorten-shapes.ttl
+++ b/src/test/resources/shacl/w3ctestsuite/core/property/in-query-001c-shorten-shapes.ttl
@@ -10,7 +10,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 neo:ShapeClass
-  sh:targetQuery " size((focus)-[:ns0__rel]-()) > 3 " ;
+  sh:targetQuery " size([(focus)-[r:ns0__rel]-() | id(r)]) > 3 " ;
   rdf:type sh:NodeShape ;
   sh:property ex:ShapeClass-property ;
 .


### PR DESCRIPTION
Neo4j in-memory test database only instantiated once per test class instead of once per test method.

Updated tests that relied on internal id's, since the id's will keep incrementing/will differ depending on in what order the tests run.

Hopefully we can enjoy unit tests that run faster!