### PR TITLE
updated docs with correct settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you want have the http endpoint mounted on your DB server, you'll need to
 add the following line to your config. 
 
   ```
-  dbms.unmanaged_extension_classes=n10s.endpoint=/rdf
+  server.unmanaged_extension_classes=n10s.endpoint=/rdf
   ```
 In the desktop you'll be able to do this by clicking on the 
 three dots to the right hand side of your database and then select settings. 
@@ -42,7 +42,7 @@ You can add the fragment at the end of the file.
 it in the <NEO_HOME>/plugins directory of your Neo4j instance. 
 2. Add the following line to your <NEO_HOME>/conf/neo4j.conf
       ```
-      dbms.unmanaged_extension_classes=n10s.endpoint=/rdf
+      server.unmanaged_extension_classes=n10s.endpoint=/rdf
       ``` 
 3. Restart the server. 
 

--- a/docs/modules/ROOT/pages/install.adoc
+++ b/docs/modules/ROOT/pages/install.adoc
@@ -9,7 +9,7 @@ You can either download a prebuilt jar from the https://github.com/jbarrasa/neos
 +
 [source,shell]
 ----
-dbms.unmanaged_extension_classes=n10s.endpoint=/rdf
+server.unmanaged_extension_classes=n10s.endpoint=/rdf
 ----
 +
 [NOTE]

--- a/index.html
+++ b/index.html
@@ -548,7 +548,7 @@ lossless manner (imported RDF can subsequently be exported without losing a sing
 </div>
 <div class="listingblock">
 <div class="content">
-<pre>dbms.unmanaged_extension_classes=n10s.extension=/rdf</pre>
+<pre>server.unmanaged_extension_classes=n10s.extension=/rdf</pre>
 </div>
 </div>
 <div class="olist arabic">

--- a/src/test/resources/test-db.properties
+++ b/src/test/resources/test-db.properties
@@ -1,2 +1,2 @@
 #org.neo4j.server.thirdparty_jaxrs_classes=org.neo4j.cypher_rs=/test
-dbms.unmanaged_extension_classes=n10s.extension=/rdf
+server.unmanaged_extension_classes=n10s.extension=/rdf


### PR DESCRIPTION
updated docs with correct neo4j.conf settings, from  `dbms.` to `server.`, deprecated from 5.x version