### PR TITLE
changes docs migration to include 5.26 as well

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -45,7 +45,7 @@
 // ** xref:reference.adoc#_utility_functions[12.2. Utility Functions]
 // ** xref:reference.adoc#_extensions_http_endpoints[12.3. Extensions (HTTP endpoints)]
 * xref:examples.adoc[13. Projects using Neosemantics]
-** xref:appendix_migration2025.adoc[A. Migrating from neosemantics 4.x and 5.x to 2025.x]
+** xref:appendix_migration_5.26-2025.x.adoc[A. Migrating from neosemantics 4.x and 5.x to 2025.x]
 * xref:appendix_migration.adoc[B. Migrating from neosemantics 3 to 4]
 // ** xref:appendix_migration.adoc#_who_should_read_this_guide[A.1. Who should read this guide]
 // ** xref:appendix_migration.adoc#_changes_in_neosemantics_4_x[A.2. Changes in neosemantics 4.x]

--- a/docs/modules/ROOT/pages/appendix_migration_5.26-2025.x.adoc
+++ b/docs/modules/ROOT/pages/appendix_migration_5.26-2025.x.adoc
@@ -1,20 +1,20 @@
-= Appendix A. Migrating to 2025.x
+= Appendix A. Migrating to 5.26 and 2025.x
 
 
 :page-pagination:
 
 [abstract]
-If you have previously used neosemantics up to v5.x, you can find the information you will need to migrate to using neosemantics v2025.x.
+If you have previously used neosemantics up to v5.20, you can find the information you will need to migrate to neosemantics v5.26 and v2025.x.
 
 == Who should read this guide
 
 This documentation is intended for users who are familiar with neosemantics. Based on this assumption, we are intentionally brief in the examples and comparisons.
 
-=== Changes in neosemantics 2025.x
+=== Changes in neosemantics v5.26 and 2025.x
 
 ==== Changes to the URL structure of the RDF endpoint
 
-Starting with Neo4j 2025.x that use recent versions of the Jetty web server (that is Jetty 12), the structure for URLs sent to the RDF description endpoint has become stricter. Passing a full URI containing encoded slashes (`%2F`) directly within the URL path is no longer permitted and will result in an `HTTP 400 Bad Request` error.
+Starting with Neo4j 5.26 and 2025.x that use recent versions of the Jetty web server (that is Jetty 12), the structure for URLs sent to the RDF description endpoint has become stricter. Passing a full URI containing encoded slashes (`%2F`) directly within the URL path is no longer permitted and will result in an `HTTP 400 Bad Request` error.
 
 Therefore, the `/rdf/<dbname>/describe/<nodeid or uri>` endpoint is changed.
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -19,7 +19,7 @@ The guide covers the following areas:
 * xref:inference.adoc[Chapter 11, Inferencing/Reasoning] — A detailed guide to inferencing and reasoning.
 * xref:reference.adoc[Chapter 12, Neosemantics Reference] — An overview of all procedures and functions in the library.
 * xref:examples.adoc[Chapter 13, Projects using Neosemantics] — A list of projects using n10s.
-* xref:appendix_migration2025.adoc[Appendix A, Migrating from neosemantics 4.x and 5.x to 2025.x] — A guide for neosemantics 4.x and 5.x users
+* xref:appendix_migration_5.26-2025.x.adoc[Appendix A, Migrating from neosemantics 4.x and 5.x to 5.26 and 2025.x] — A guide for neosemantics 4.x and 5.20 users
 * xref:appendix_migration.adoc[Appendix B, Migrating from neosemantics 3 to 4] — A guide for neosemantics 3.x users
 
 image::nsmntx-block-diagram.png[Neosemantics diagram, 200,align="center"]


### PR DESCRIPTION
Changed migration docs, consistent to https://github.com/neo4j-labs/neosemantics/pull/331