### PR TITLE
fix teamcity endpoint test error 2025.06

### DIFF
--- a/src/test/java/n10s/endpoint/RDFEndpointTest.java
+++ b/src/test/java/n10s/endpoint/RDFEndpointTest.java
@@ -1033,7 +1033,7 @@ public class RDFEndpointTest {
     response = HTTP.withHeaders("Accept", "application/ld+json").GET(
         resolveURI(neo4j.httpURI(), "neo4j/describe/find/Something"));
 
-    assertEquals("{\"errors\":[{\"code\":\"Neo.ClientError.Request.Invalid\",\"message\":\"Not Found\"}]}", response.rawContent());
+    assertEquals("", response.rawContent());
     assertEquals(404, response.status());
   }
 


### PR DESCRIPTION
Starting from neo4j 5+ the endpoint handling is changed.
Fixed the `testFindNodeByLabelAndPropertyNotFoundOrInvalid` test like fixed [here](https://github.com/neo4j-labs/neosemantics/commit/f0aed454c8b6ba103d80fb1038349ec721b3bff7#diff-f7c4e4ccd6fd8cc33d59d163f6474f1ea8eb18f8467793cacd335f73a4d01b5aR384) for the [5.20 one](https://github.com/neo4j-labs/neosemantics/blob/5.20/src/test/java/n10s/endpoint/RDFEndpointTest.java#L1044) 