### PR TITLE
Fixes #343: neosemantics-5.26.0.jar bundles incompatible jackson-annotations and prevents Neo4j 5.26.24 from starting on RHEL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,6 +233,15 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <artifactSet>
+                <excludes>
+                  <exclude>com.fasterxml.jackson.core:*</exclude>
+                  <exclude>com.fasterxml.jackson.datatype:*</exclude>
+                  <exclude>com.fasterxml.jackson.dataformat:*</exclude>
+                  <exclude>com.fasterxml.jackson.module:*</exclude>
+                  <exclude>com.fasterxml.jackson.jaxrs:*</exclude>
+                </excludes>
+              </artifactSet>
               <transformers>
                 <transformer
                   implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>


### PR DESCRIPTION
Fixes #343

### The Issue
The error was caused by a jackson conflig. 
Neo4j Enterprise 5.26.24 ships with Jackson **2.21.1**, while the neosemantics plugin was bundling its own (older) version of `jackson-annotations` (2.18.0) via the Maven Shade Plugin.

### Environment Specificity

Using MacOS, this bug only occurs on Neo4j Enterprise Docker and not on Community or Desktop editions, 
possibly due to a different JAR loading order or file system differences that allowed the correct version of Jackson to take precedence over the bundled one

### Changes
-  **Modified `maven-shade-plugin` configuration**: Added explicit exclusions for all Jackson-related artifacts present in Neo4j lib (`core`, `databind`, `annotations`, `datatype`, `dataformat`, `module`, `jaxrs`)

### Before vs After
**BEFORE:**
Running `unzip -l` on the previous build showed that Jackson classes were being incorrectly bundled inside the plugin JAR:
```bash
$ unzip -l target/neosemantics-5.26.0.jar | grep jackson
0  05-07-2026 15:45   com/fasterxml/jackson/
0  05-07-2026 15:45   com/fasterxml/jackson/annotation/
429  05-07-2026 15:45   com/fasterxml/jackson/annotation/JacksonAnnotation.class
...
1081  05-07-2026 15:45   com/fasterxml/jackson/annotation/JsonProperty.class
...
```

**AFTER:**
The `com/fasterxml/jackson/` directory is now completely absent from the JAR. The plugin will now correctly use the libraries provided by the Neo4j runtime environment.
```bash
$ unzip -l target/neosemantics-5.26.0.jar | grep jackson
<empty result>
...
```
