### PR TITLE
Fixes #340: exclude Jackson from shaded JAR (2026.01 branch)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,15 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <artifactSet>
+                <excludes>
+                  <exclude>com.fasterxml.jackson.core:*</exclude>
+                  <exclude>com.fasterxml.jackson.datatype:*</exclude>
+                  <exclude>com.fasterxml.jackson.dataformat:*</exclude>
+                  <exclude>com.fasterxml.jackson.module:*</exclude>
+                  <exclude>com.fasterxml.jackson.jaxrs:*</exclude>
+                </excludes>
+              </artifactSet>
               <transformers>
                 <transformer
                   implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>


### PR DESCRIPTION
## Problem

Neo4j 2026.01.x ships its own Jackson version. When neosemantics bundles a conflicting Jackson version inside its shaded JAR via `maven-shade-plugin`, Neo4j fails to start with `NoSuchMethodError` or similar class-loading conflicts (same root cause as #343 fixed for 5.26 in #344).

## Fix

Added `<artifactSet><excludes>` to the `maven-shade-plugin` configuration in `pom.xml` to prevent all `com.fasterxml.jackson.*` groups from being bundled into the plugin JAR. Jackson is already present at runtime via Neo4j's own bundled version.

Groups excluded:
- `com.fasterxml.jackson.core:*`
- `com.fasterxml.jackson.datatype:*`
- `com.fasterxml.jackson.dataformat:*`
- `com.fasterxml.jackson.module:*`
- `com.fasterxml.jackson.jaxrs:*`

Closes #340. Backport of #344 to the `2026.01` branch.