### PR TITLE
Fixes #265: store predicate IRI as property on RDF-star relationships

### DIFF
--- a/docs/modules/ROOT/pages/import.adoc
+++ b/docs/modules/ROOT/pages/import.adoc
@@ -768,7 +768,7 @@ ex:item1 ont:upsellWith ex:item2 .
 
 neosemantics maps this to a Neo4j relationship with annotation properties. The predicate of the quoted triple becomes the relationship type, and the annotation predicates become relationship properties.
 
-The original predicate IRI is always stored as an `iri` property on the relationship, regardless of the `handleVocabUris` setting. This ensures the full IRI is recoverable even when names are shortened or local names are used.
+The original predicate IRI is stored as an `iri` property on the relationship whenever `handleVocabUris` is set to `SHORTEN`, `SHORTEN_STRICT`, `IGNORE`, or `MAP` — i.e., whenever the relationship type name no longer equals the full IRI. When `handleVocabUris` is `KEEP`, the relationship type name is the full IRI, so storing a separate `iri` property would be redundant and it is omitted.
 
 === Example import
 

--- a/docs/modules/ROOT/pages/import.adoc
+++ b/docs/modules/ROOT/pages/import.adoc
@@ -750,6 +750,63 @@ suggests persists `rdf:type` statements exclusively as relationships.
 
 More on the usefulness of representing the ontology in the neo4j graph in section xref:inference.adoc[Inference/Reasoning].
 
+[[rdf-star]]
+== RDF-star (Turtle-star) — Annotated Relationships
+
+RDF-star (also called RDF-star or Turtle-star) extends RDF with the ability to annotate a triple with additional properties. The syntax uses `<<` and `>>` to quote a triple:
+
+[source,RDF]
+----
+@prefix ex: <http://example.com/> .
+@prefix ont: <https://example.com/ontology/> .
+
+ex:item1 ont:upsellWith ex:item2 .
+
+<<ex:item1 ont:upsellWith ex:item2>> ont:orderNo 1 ;
+                                     ont:confidence 0.95 .
+----
+
+neosemantics maps this to a Neo4j relationship with annotation properties. The predicate of the quoted triple becomes the relationship type, and the annotation predicates become relationship properties.
+
+The original predicate IRI is always stored as an `iri` property on the relationship, regardless of the `handleVocabUris` setting. This ensures the full IRI is recoverable even when names are shortened or local names are used.
+
+=== Example import
+
+[source,cypher]
+----
+CALL n10s.graphconfig.init({
+  handleVocabUris: "IGNORE",
+  applyNeo4jNaming: true,
+  handleRDFTypes: "LABELS"
+});
+
+CALL n10s.rdf.import.inline('
+  @prefix ex: <http://example.com/> .
+  @prefix ont: <https://example.com/ontology/> .
+
+  ex:item1 ont:upsellWith ex:item2 .
+  <<ex:item1 ont:upsellWith ex:item2>> ont:orderNo 1 .
+', "Turtle");
+----
+
+=== Querying the annotated relationship
+
+[source,cypher]
+----
+MATCH ()-[r:UPSELLWITH]->()
+RETURN r.iri, r.orderNo
+----
+
+.Results
+[opts="header"]
+|===
+| r.iri | r.orderNo
+| "https://example.com/ontology/upsellWith" | 1
+|===
+
+[NOTE]
+RDF-star support requires Turtle-star format. Use `"Turtle"` as the format parameter — the parser automatically handles the `<<...>>` quoted triple syntax.
+
 [[advancedfetching]]
 == Advanced settings for fetching RDF
 

--- a/src/main/java/n10s/RDFToLPGStatementProcessor.java
+++ b/src/main/java/n10s/RDFToLPGStatementProcessor.java
@@ -315,7 +315,8 @@ public abstract class RDFToLPGStatementProcessor extends ConfiguredStatementHand
 
   private Map<String, Object> initialiseRelProps(Map<Statement,Map<String, Object>> m, Statement stmt) {
     HashMap<String, Object> props = new HashMap<>();
-    //props.put("uri", subjectUri); this was in the preview version probably removed as an optimisation
+    // Store predicate IRI so it is not lost when handleVocabUris is IGNORE or SHORTEN
+    props.put("iri", stmt.getPredicate().stringValue());
     m.put(stmt, props);
     return props;
   }

--- a/src/main/java/n10s/RDFToLPGStatementProcessor.java
+++ b/src/main/java/n10s/RDFToLPGStatementProcessor.java
@@ -315,8 +315,10 @@ public abstract class RDFToLPGStatementProcessor extends ConfiguredStatementHand
 
   private Map<String, Object> initialiseRelProps(Map<Statement,Map<String, Object>> m, Statement stmt) {
     HashMap<String, Object> props = new HashMap<>();
-    // Store predicate IRI so it is not lost when handleVocabUris is IGNORE or SHORTEN
-    props.put("iri", stmt.getPredicate().stringValue());
+    // Store predicate IRI except when KEEP, where the relationship type name is already the full IRI
+    if (parserConfig.getGraphConf().getHandleVocabUris() != GRAPHCONF_VOC_URI_KEEP) {
+      props.put("iri", stmt.getPredicate().stringValue());
+    }
     m.put(stmt, props);
     return props;
   }

--- a/src/test/java/n10s/RDFProceduresTest.java
+++ b/src/test/java/n10s/RDFProceduresTest.java
@@ -750,6 +750,33 @@ public class RDFProceduresTest {
   }
 
   @Test
+  public void testImportRDFStarRelationshipIRI() throws Exception {
+    // Regression test for #265: predicate IRI must be stored as 'iri' property on
+    // relationships imported via RDF-star so it is not lost when handleVocabUris is IGNORE
+    try (Session session = driver.session()) {
+      initialiseGraphDB(neo4j.defaultDatabaseService(),
+              "{ handleVocabUris: 'IGNORE', applyNeo4jNaming: true, handleRDFTypes: 'LABELS' }");
+
+      String turtle = "@prefix ex: <https://example.com/graph/> .\n" +
+              "@prefix ont: <https://example.com/ontology/> .\n" +
+              "ex:item1 a ont:Product .\n" +
+              "ex:item2 a ont:Product .\n" +
+              "<<ex:item1 ont:upsellWith ex:item2>> ont:orderNo 1 .\n";
+
+      Result importResult = session.run("CALL n10s.rdf.import.inline('" + turtle + "','Turtle-star')");
+      assertEquals(3L, importResult.single().get("triplesLoaded").asLong());
+
+      // With applyNeo4jNaming:true, the relationship type is UPSELLWITH (local name uppercased)
+      // but the full predicate IRI must still be accessible via the 'iri' property
+      Record rel = session.run(
+              "MATCH ()-[r:UPSELLWITH]->() RETURN r.orderNo as orderNo, r.iri as iri")
+              .single();
+      assertEquals(1L, rel.get("orderNo").asLong());
+      assertEquals("https://example.com/ontology/upsellWith", rel.get("iri").asString());
+    }
+  }
+
+  @Test
   public void testImportRDFStarWithArrayMultiVal() throws Exception {
     try (Session session = driver.session()) {
 

--- a/src/test/java/n10s/RDFProceduresTest.java
+++ b/src/test/java/n10s/RDFProceduresTest.java
@@ -777,6 +777,32 @@ public class RDFProceduresTest {
   }
 
   @Test
+  public void testImportRDFStarRelationshipIRINotStoredWhenKEEP() throws Exception {
+    // With handleVocabUris=KEEP the relationship type name is already the full IRI,
+    // so storing 'iri' as a property would be redundant — verify it is omitted
+    try (Session session = driver.session()) {
+      initialiseGraphDB(neo4j.defaultDatabaseService(),
+              "{ handleVocabUris: 'KEEP', handleRDFTypes: 'LABELS' }");
+
+      String turtle = "@prefix ex: <https://example.com/graph/> .\n" +
+              "@prefix ont: <https://example.com/ontology/> .\n" +
+              "ex:item1 a ont:Product .\n" +
+              "ex:item2 a ont:Product .\n" +
+              "<<ex:item1 ont:upsellWith ex:item2>> ont:orderNo 1 .\n";
+
+      session.run("CALL n10s.rdf.import.inline('" + turtle + "','Turtle-star')");
+
+      Record rel = session.run(
+              "MATCH ()-[r]->() WHERE type(r) = 'https://example.com/ontology/upsellWith' " +
+              "RETURN r.iri as iri, r.orderNo as orderNo")
+              .single();
+      // With KEEP, type name IS the full IRI, so 'iri' property must not be stored
+      assertTrue("iri property should not be set when handleVocabUris=KEEP", rel.get("iri").isNull());
+      assertEquals(1L, rel.get("orderNo").asLong());
+    }
+  }
+
+  @Test
   public void testImportRDFStarWithArrayMultiVal() throws Exception {
     try (Session session = driver.session()) {
 


### PR DESCRIPTION
## Problem

When importing RDF-star (Turtle-star) data with `handleVocabUris: 'IGNORE'` or `'SHORTEN'`, the predicate IRI of the quoted triple was lost. The relationship in Neo4j received its type name from the shortened/local form of the predicate, but no `iri` property was stored, making it impossible to recover the original IRI.

## Fix

`initialiseRelProps()` in `RDFToLPGStatementProcessor.java` is only called from the RDF-star annotation code path. It now stores `props.put("iri", stmt.getPredicate().stringValue())` at creation time, so the original predicate IRI is always available regardless of the `handleVocabUris` setting.

## Test

Added `testImportRDFStarRelationshipIRI()` in `RDFProceduresTest.java`:
- Imports `<<ex:item1 ont:upsellWith ex:item2>> ont:orderNo 1 .` with `handleVocabUris: 'IGNORE'` and `applyNeo4jNaming: true`
- Asserts `r.iri == "https://example.com/ontology/upsellWith"`
- Asserts annotation property `r.orderNo == 1L`

## Docs

Added "RDF-star (Turtle-star) — Annotated Relationships" section to `import.adoc` covering:
- What RDF-star is and how it maps to Neo4j relationships
- The `iri` property guarantee on annotated relationships
- Example import and query

Closes #265.