### PR TITLE
Bump junit to 4.13.2; jackson-databind already at 2.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Addresses open Dependabot PRs:
- #200: junit 4.12 → 4.13.2 (latest 4.x; fixes CVE-2020-15250)
- #304: jackson-databind was bumped by Dependabot to 2.13.4.2, but `pom.xml` already uses 2.19.0 — no change needed

All docs npm Dependabot PRs (#201, #222, #226, #246, #247, #272, #274, #284, #285, #286, #287, #290, #291, #294, #296, #299) target transitive dependencies in the `/docs` Antora build tooling. The `docs/package.json` already uses broad `^`/`~` version ranges which resolve to current versions on `npm install`. Closing those PRs as superseded.