### PR TITLE
Fix docs typos (closes #218; #179 and #250 already fixed on 2026.01)

### DIFF
--- a/docs/modules/ROOT/pages/import.adoc
+++ b/docs/modules/ROOT/pages/import.adoc
@@ -741,7 +741,7 @@ the instances to the previously loaded ontology.
 call n10s.rdf.import.fetch("https://github.com/neo4j-labs/neosemantics/raw/3.5/docs/rdf/miniinstances.ttl","Turtle");
 ----
 
-The resulting graph connects the instance data to the ontology elements. This is the magic of unique identifiers (uris), tere's nothing you need to do for the linkage to happen, if your RDF is well formed and uris are used consistently in it, then it will happen automatically.
+The resulting graph connects the instance data to the ontology elements. This is the magic of unique identifiers (uris), there's nothing you need to do for the linkage to happen, if your RDF is well formed and uris are used consistently in it, then it will happen automatically.
 
 image::miniontoandinstances.png[Connected ontology and instance data imported in Neo4j,scaledwidth="100%"]
 


### PR DESCRIPTION
Fixes the remaining open docs typo PR:
- #218: `"tere's"` → `"there's"` in `import.adoc`

PRs #179 (localhos → localhost in install.adoc) and #250 (wrong README link) were already applied on the `2026.01` branch.