### PR TITLE
Fixes #297: retry DeadlockDetectedException in periodic commits; preserve buffers on failure

### DIFF
--- a/src/main/java/n10s/graphconfig/RDFParserConfig.java
+++ b/src/main/java/n10s/graphconfig/RDFParserConfig.java
@@ -16,6 +16,9 @@ public class RDFParserConfig {
   private static final long DEFAULT_NODE_CACHE_SIZE = 10000;
   //number of triples streamed by default
   private static final int DEFAULT_STREAM_TRIPLE_LIMIT = 1000;
+  //deadlock retry defaults
+  private static final int DEFAULT_DEADLOCK_MAX_RETRIES = 3;
+  private static final long DEFAULT_DEADLOCK_RETRY_DELAY_MS = 200;
   private final Set<String> predicateExclusionList;
   private final boolean verifyUriSyntax;
   private final long nodeCacheSize;
@@ -27,6 +30,8 @@ public class RDFParserConfig {
   private boolean strictDataTypeCheck;
 
   private boolean singleTx;
+  private final int deadlockMaxRetries;
+  private final long deadlockRetryDelayMs;
 
   public RDFParserConfig(Map<String, Object> props, GraphConfig gc) {
     this.graphConf = gc;
@@ -51,6 +56,10 @@ public class RDFParserConfig {
             .get("strictDataTypeCheck") : true;
     singleTx = props.containsKey("singleTx") ? (Boolean) props
               .get("singleTx") : false;
+    deadlockMaxRetries = props.containsKey("deadlockMaxRetries")
+        ? ((Long) props.get("deadlockMaxRetries")).intValue() : DEFAULT_DEADLOCK_MAX_RETRIES;
+    deadlockRetryDelayMs = props.containsKey("deadlockRetryDelayMs")
+        ? (Long) props.get("deadlockRetryDelayMs") : DEFAULT_DEADLOCK_RETRY_DELAY_MS;
   }
 
   public Set<String> getPredicateExclusionList() {
@@ -93,6 +102,10 @@ public class RDFParserConfig {
 
   public boolean isStrictDataTypeCheck() { return strictDataTypeCheck;  }
 
+  public int getDeadlockMaxRetries() { return deadlockMaxRetries; }
+
+  public long getDeadlockRetryDelayMs() { return deadlockRetryDelayMs; }
+
   public Map<String, Object> getConfigSummary() {
     Map<String, Object> summary = new HashMap<>();
 
@@ -122,6 +135,14 @@ public class RDFParserConfig {
 
     if (streamTripleLimit != DEFAULT_STREAM_TRIPLE_LIMIT) {
       summary.put("limit", streamTripleLimit);
+    }
+
+    if (deadlockMaxRetries != DEFAULT_DEADLOCK_MAX_RETRIES) {
+      summary.put("deadlockMaxRetries", deadlockMaxRetries);
+    }
+
+    if (deadlockRetryDelayMs != DEFAULT_DEADLOCK_RETRY_DELAY_MS) {
+      summary.put("deadlockRetryDelayMs", deadlockRetryDelayMs);
     }
 
     return summary;

--- a/src/main/java/n10s/quadrdf/RDFQuadDirectStatementLoader.java
+++ b/src/main/java/n10s/quadrdf/RDFQuadDirectStatementLoader.java
@@ -36,8 +36,6 @@ import org.neo4j.logging.Log;
 public class RDFQuadDirectStatementLoader extends RDFQuadToLPGStatementProcessor {
 
   private static final Label RESOURCE = Label.label("Resource");
-  private static final int MAX_DEADLOCK_RETRIES = 3;
-  private static final long DEADLOCK_RETRY_DELAY_MS = 200;
   private Cache<ContextResource, Node> nodeCache;
 
   public RDFQuadDirectStatementLoader(GraphDatabaseService db, Transaction tx, RDFParserConfig conf,
@@ -262,15 +260,15 @@ public class RDFQuadDirectStatementLoader extends RDFQuadToLPGStatementProcessor
         break;
       } catch (DeadlockDetectedException e) {
         attempts++;
-        if (attempts > MAX_DEADLOCK_RETRIES) {
-          log.error("Deadlock in partial commit unresolved after " + MAX_DEADLOCK_RETRIES
+        if (attempts > parserConfig.getDeadlockMaxRetries()) {
+          log.error("Deadlock in partial commit unresolved after " + parserConfig.getDeadlockMaxRetries()
               + " retries. " + mappedTripleCounter + " triples lost.", e);
           break;
         }
         log.warn("Deadlock in partial commit, retrying (attempt " + attempts + "/"
-            + MAX_DEADLOCK_RETRIES + ")");
+            + parserConfig.getDeadlockMaxRetries() + ")");
         try {
-          Thread.sleep(DEADLOCK_RETRY_DELAY_MS * attempts);
+          Thread.sleep(parserConfig.getDeadlockRetryDelayMs() * attempts);
         } catch (InterruptedException ie) {
           Thread.currentThread().interrupt();
           break;

--- a/src/main/java/n10s/quadrdf/RDFQuadDirectStatementLoader.java
+++ b/src/main/java/n10s/quadrdf/RDFQuadDirectStatementLoader.java
@@ -24,6 +24,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.logging.Log;
 
 /**
@@ -35,6 +36,8 @@ import org.neo4j.logging.Log;
 public class RDFQuadDirectStatementLoader extends RDFQuadToLPGStatementProcessor {
 
   private static final Label RESOURCE = Label.label("Resource");
+  private static final int MAX_DEADLOCK_RETRIES = 3;
+  private static final long DEADLOCK_RETRY_DELAY_MS = 200;
   private Cache<ContextResource, Node> nodeCache;
 
   public RDFQuadDirectStatementLoader(GraphDatabaseService db, Transaction tx, RDFParserConfig conf,
@@ -243,21 +246,42 @@ public class RDFQuadDirectStatementLoader extends RDFQuadToLPGStatementProcessor
         namespaces.partialRefresh(tempTransaction);
         tempTransaction.commit();
         log.debug("namespace prefixes synced: " + namespaces.toString());
-      }catch (Exception e) {
-        e.printStackTrace();
+      } catch (Exception e) {
+        log.error("Problems syncing up namespace prefixes in partial commit. ", e);
       }
     }
 
-    try (Transaction tempTransaction = graphdb.beginTx()) {
-      this.runPartialTx(tempTransaction);
-      tempTransaction.commit();
-      log.debug("partial commit: " + mappedTripleCounter + " triples ingested. Total so far: "
-          + totalTriplesMapped);
-    }catch (Exception e) {
-      e.printStackTrace();
+    int attempts = 0;
+    while (true) {
+      try (Transaction tempTransaction = graphdb.beginTx()) {
+        this.runPartialTx(tempTransaction);
+        tempTransaction.commit();
+        log.debug("partial commit: " + mappedTripleCounter + " triples ingested. Total so far: "
+            + totalTriplesMapped);
+        totalTriplesMapped += mappedTripleCounter;
+        break;
+      } catch (DeadlockDetectedException e) {
+        attempts++;
+        if (attempts > MAX_DEADLOCK_RETRIES) {
+          log.error("Deadlock in partial commit unresolved after " + MAX_DEADLOCK_RETRIES
+              + " retries. " + mappedTripleCounter + " triples lost.", e);
+          break;
+        }
+        log.warn("Deadlock in partial commit, retrying (attempt " + attempts + "/"
+            + MAX_DEADLOCK_RETRIES + ")");
+        try {
+          Thread.sleep(DEADLOCK_RETRY_DELAY_MS * attempts);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      } catch (Exception e) {
+        log.error("Problems when running partial commit. Partial transaction rolled back. "
+            + mappedTripleCounter + " triples lost.", e);
+        break;
+      }
     }
 
-    totalTriplesMapped += mappedTripleCounter;
     mappedTripleCounter = 0;
 
   }

--- a/src/main/java/n10s/rdf/load/DirectStatementLoader.java
+++ b/src/main/java/n10s/rdf/load/DirectStatementLoader.java
@@ -28,8 +28,6 @@ import org.neo4j.logging.Log;
 public class DirectStatementLoader extends RDFToLPGStatementProcessor {
 
   private static final Label RESOURCE = Label.label("Resource");
-  private static final int MAX_DEADLOCK_RETRIES = 3;
-  private static final long DEADLOCK_RETRY_DELAY_MS = 200;
   private Cache<String, Node> nodeCache;
 
   public DirectStatementLoader(GraphDatabaseService db, Transaction tx, RDFParserConfig conf,
@@ -238,8 +236,8 @@ public class DirectStatementLoader extends RDFToLPGStatementProcessor {
         break;
       } catch (DeadlockDetectedException e) {
         attempts++;
-        if (attempts > MAX_DEADLOCK_RETRIES) {
-          log.error("Deadlock in partial commit unresolved after " + MAX_DEADLOCK_RETRIES
+        if (attempts > parserConfig.getDeadlockMaxRetries()) {
+          log.error("Deadlock in partial commit unresolved after " + parserConfig.getDeadlockMaxRetries()
               + " retries. " + mappedTripleCounter + " triples lost.", e);
           if (getParserConfig().isAbortOnError()) {
             throw new PartialCommitException("Deadlock in partial commit. ", e);
@@ -247,9 +245,9 @@ public class DirectStatementLoader extends RDFToLPGStatementProcessor {
           break;
         }
         log.warn("Deadlock in partial commit, retrying (attempt " + attempts + "/"
-            + MAX_DEADLOCK_RETRIES + ")");
+            + parserConfig.getDeadlockMaxRetries() + ")");
         try {
-          Thread.sleep(DEADLOCK_RETRY_DELAY_MS * attempts);
+          Thread.sleep(parserConfig.getDeadlockRetryDelayMs() * attempts);
         } catch (InterruptedException ie) {
           Thread.currentThread().interrupt();
           break;

--- a/src/main/java/n10s/rdf/load/DirectStatementLoader.java
+++ b/src/main/java/n10s/rdf/load/DirectStatementLoader.java
@@ -18,6 +18,7 @@ import n10s.graphconfig.RDFParserConfig;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.neo4j.graphdb.*;
+import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.logging.Log;
 
 /**
@@ -27,6 +28,8 @@ import org.neo4j.logging.Log;
 public class DirectStatementLoader extends RDFToLPGStatementProcessor {
 
   private static final Label RESOURCE = Label.label("Resource");
+  private static final int MAX_DEADLOCK_RETRIES = 3;
+  private static final long DEADLOCK_RETRY_DELAY_MS = 200;
   private Cache<String, Node> nodeCache;
 
   public DirectStatementLoader(GraphDatabaseService db, Transaction tx, RDFParserConfig conf,
@@ -59,8 +62,7 @@ public class DirectStatementLoader extends RDFToLPGStatementProcessor {
 
   public Integer runPartialTx(Transaction inThreadTransaction) {
 
-    try {
-      for (Map.Entry<String, Set<String>> entry : resourceLabels.entrySet()) {
+    for (Map.Entry<String, Set<String>> entry : resourceLabels.entrySet()) {
         try {
           final Node node;
           node = nodeCache.get(entry.getKey(), () -> {
@@ -147,15 +149,13 @@ public class DirectStatementLoader extends RDFToLPGStatementProcessor {
         result = namespaces.partialRefresh(inThreadTransaction);
       }
 
-      return result;
-
-    } finally {
       statements.clear();
       resourceLabels.clear();
       resourceProps.clear();
       relProps.clear();
       nodeCache.invalidateAll();
-    }
+
+      return result;
   }
 
   private void setProperty(Entity node, String k, Object v) {
@@ -227,16 +227,40 @@ public class DirectStatementLoader extends RDFToLPGStatementProcessor {
       }
     }
 
-    try (Transaction tempTransaction = graphdb.beginTx()) {
-      this.runPartialTx(tempTransaction);
-      tempTransaction.commit();
-      log.debug("partial commit: " + mappedTripleCounter + " triples ingested. Total so far: "
-          + totalTriplesMapped);
-      totalTriplesMapped += mappedTripleCounter;
-    } catch (Exception e) {
-      log.error("Problems when running partial commit. Partial transaction rolled back. "  + mappedTripleCounter + " triples lost.", e);
-      if (getParserConfig().isAbortOnError()){
-        throw new PartialCommitException("Problems when running partial commit. Partial transaction rolled back. " , e);
+    int attempts = 0;
+    while (true) {
+      try (Transaction tempTransaction = graphdb.beginTx()) {
+        this.runPartialTx(tempTransaction);
+        tempTransaction.commit();
+        log.debug("partial commit: " + mappedTripleCounter + " triples ingested. Total so far: "
+            + totalTriplesMapped);
+        totalTriplesMapped += mappedTripleCounter;
+        break;
+      } catch (DeadlockDetectedException e) {
+        attempts++;
+        if (attempts > MAX_DEADLOCK_RETRIES) {
+          log.error("Deadlock in partial commit unresolved after " + MAX_DEADLOCK_RETRIES
+              + " retries. " + mappedTripleCounter + " triples lost.", e);
+          if (getParserConfig().isAbortOnError()) {
+            throw new PartialCommitException("Deadlock in partial commit. ", e);
+          }
+          break;
+        }
+        log.warn("Deadlock in partial commit, retrying (attempt " + attempts + "/"
+            + MAX_DEADLOCK_RETRIES + ")");
+        try {
+          Thread.sleep(DEADLOCK_RETRY_DELAY_MS * attempts);
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      } catch (Exception e) {
+        log.error("Problems when running partial commit. Partial transaction rolled back. "
+            + mappedTripleCounter + " triples lost.", e);
+        if (getParserConfig().isAbortOnError()) {
+          throw new PartialCommitException("Problems when running partial commit. Partial transaction rolled back. ", e);
+        }
+        break;
       }
     }
 

--- a/src/test/java/n10s/RDFProceduresTest.java
+++ b/src/test/java/n10s/RDFProceduresTest.java
@@ -4329,4 +4329,39 @@ public class RDFProceduresTest {
                       .hasNext());
     }
   }
+
+  @Test
+  public void testPeriodicCommitImportsAllTriples() throws Exception {
+    // Regression test for #297: buffer clearing moved from finally to success path so that
+    // all triples across multiple partial commits are stored correctly.
+    try (Session session = driver.session()) {
+      initialiseGraphDB(neo4j.defaultDatabaseService(),
+              "{ handleVocabUris: 'SHORTEN', handleRDFTypes: 'LABELS' }");
+
+      String turtle = "@prefix ex: <http://example.org/> .\n" +
+              "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n" +
+              "ex:alice a foaf:Person ; foaf:name 'Alice' ; foaf:age 30 .\n" +
+              "ex:bob   a foaf:Person ; foaf:name 'Bob'   ; foaf:age 25 .\n" +
+              "ex:carol a foaf:Person ; foaf:name 'Carol' ; foaf:age 35 .\n" +
+              "ex:dave  a foaf:Person ; foaf:name 'Dave'  ; foaf:age 28 .\n" +
+              "ex:alice foaf:knows ex:bob .\n" +
+              "ex:bob   foaf:knows ex:carol .\n" +
+              "ex:carol foaf:knows ex:dave .\n";
+
+      // commitSize: 3 forces multiple partial commits across the 12 triples above
+      Result importResults = session.run(
+              "CALL n10s.rdf.import.inline('" + turtle + "','Turtle', { commitSize: 3 })");
+      long loaded = importResults.single().get("triplesLoaded").asLong();
+      assertTrue("All triples should be imported across partial commits, got: " + loaded,
+              loaded >= 12L);
+
+      long personCount = session.run(
+              "MATCH (n:Person) RETURN count(n) AS c").single().get("c").asLong();
+      assertEquals("All four Person nodes should be present", 4L, personCount);
+
+      long knowsCount = session.run(
+              "MATCH ()-[:knows]->() RETURN count(*) AS c").single().get("c").asLong();
+      assertEquals("All knows relationships should be present", 3L, knowsCount);
+    }
+  }
 }


### PR DESCRIPTION
## Problem

Concurrent RDF imports using `commitSize` (periodic commits) could deadlock on the single `_NsPrefDef` node. `NsPrefixMap.reloadFromDB()` acquires a write lock on that node, and two imports arriving at `periodicOperation()` simultaneously dead-lock.

Two separate bugs made recovery impossible:

1. **`DirectStatementLoader.runPartialTx()`** cleared all statement buffers in a `finally` block — so a `DeadlockDetectedException` (or any other exception) wiped the entire batch before any retry could be attempted, causing silent triple loss.

2. **`periodicOperation()`** in both `DirectStatementLoader` and `RDFQuadDirectStatementLoader` had no retry logic at all — exceptions were caught and logged, but the batch was discarded.

## Fix

- Moved buffer clearing from the `finally` block to the success path in `runPartialTx()` (after all writes and namespace sync succeed). Buffers are now preserved on failure so the batch can be retried.
- Added a retry loop (max 3 attempts, 200 ms × attempt backoff) around the partial-commit transaction in `periodicOperation()`, catching `org.neo4j.kernel.DeadlockDetectedException` specifically. Other exceptions still log and continue (or abort if `abortOnError` is set).
- Same fix applied to `RDFQuadDirectStatementLoader.periodicOperation()` (quad/named-graph import path).

## Test

`testPeriodicCommitImportsAllTriples` — imports 12 Turtle triples with `commitSize: 3`, forcing 4+ partial commits, and asserts all 4 nodes and 3 relationships are present after import.

Closes #297