### PR TITLE
Fix #180: prevent import abort on malformed URIs (verifyUriSyntax:false)

### DIFF
--- a/docs/modules/ROOT/pages/import.adoc
+++ b/docs/modules/ROOT/pages/import.adoc
@@ -888,6 +888,32 @@ image::worldofyesterday.png[Graph resulting of importing the data in the British
 Of course you could do achieve this -or something similar- in different ways, in this case we are using a SPARQL CONSTRUCT query in order to be able to limit
 the number of triples returned for each resource as some of them are pretty dense.
 
+[[malformed-uris]]
+== Handling malformed URIs
+
+By default neosemantics validates URI syntax during parsing, and a single malformed URI aborts the entire import with `terminationStatus: KO`.
+
+Some real-world RDF datasets (e.g. Wikidata exports, legacy government data) contain URIs that technically violate the RFC 3986 syntax — for example, double-hash fragments (`##`) or unencoded braces.
+Setting `verifyUriSyntax: false` switches the parser to lenient mode: any triple whose subject, predicate, or object contains a malformed URI is silently skipped and logged as a warning, while all other triples continue to be imported normally.
+
+[source,cypher]
+----
+CALL n10s.rdf.import.fetch("file:///data/wikidata-export.ttl", "Turtle", {
+  verifyUriSyntax: false
+});
+----
+
+.Results — bad URIs skipped, rest of file imported
+[opts="header"]
+|===
+| terminationStatus | triplesLoaded | ...
+| "OK"              | 1234          | ...
+|===
+
+[NOTE]
+With `verifyUriSyntax: false` only the individual triples containing the malformed URI are dropped.
+If you need to inspect which triples were skipped, check the Neo4j server log for `RDF parse error (triple skipped)` warnings.
+
 [[custom-prefixes-for-namespaces]]
 == Defining custom prefixes for namespaces
 

--- a/docs/modules/ROOT/pages/reference.adoc
+++ b/docs/modules/ROOT/pages/reference.adoc
@@ -147,7 +147,7 @@ The following parameters are  specific to the import/preview/stream method.
 | headerParams      | map {} | parameters to be passed in the HTTP GET request or `payload` if POST request. <br> Example: `{ authorization: 'Basic user:pwd', Accept: 'application/rdf+xml'}`
 | commitSize      | integer (25000) | commit a partial transaction every n triples
 | nodeCacheSize      | integer (10000) | keep n nodes in cache to minimize reads from DB
-| verifyUriSyntax | boolean (true) | by default, uri syntax is checked. This can be disable d by setting this parameter to `false`
+| verifyUriSyntax | boolean (true) | by default, uri syntax is checked and a malformed URI aborts the entire import. Set to `false` to make URI parse errors non-fatal: triples whose subject, predicate, or object has a malformed URI (e.g. `##`-fragment, unencoded braces) are skipped individually and logged as warnings, while the rest of the file continues to import normally.
 |===
 
 

--- a/src/main/java/n10s/CommonProcedures.java
+++ b/src/main/java/n10s/CommonProcedures.java
@@ -21,6 +21,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.common.lang.FileFormat;
+import org.eclipse.rdf4j.rio.ParseErrorListener;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
@@ -129,6 +130,23 @@ public class CommonProcedures {
     RDFParser rdfParser = Rio.createParser(format);
     rdfParser
         .set(BasicParserSettings.VERIFY_URI_SYNTAX, handler.getParserConfig().isVerifyUriSyntax());
+    if (!handler.getParserConfig().isVerifyUriSyntax()) {
+      // When URI syntax verification is disabled, make URI parse errors non-fatal so that
+      // individual triples with malformed IRIs (e.g. ##fragment, unencoded braces) are skipped
+      // rather than aborting the whole import (see issue #180).
+      rdfParser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX);
+      rdfParser.setParseErrorListener(new ParseErrorListener() {
+        @Override public void warning(String msg, long line, long col) {
+          log.warn("RDF parse warning at line %d, col %d: %s", line, col, msg);
+        }
+        @Override public void error(String msg, long line, long col) {
+          log.warn("RDF parse error (triple skipped) at line %d, col %d: %s", line, col, msg);
+        }
+        @Override public void fatalError(String msg, long line, long col) {
+          log.warn("RDF parse fatal error at line %d, col %d: %s", line, col, msg);
+        }
+      });
+    }
     rdfParser.setRDFHandler(handler);
     rdfParser.parse(inputStream, url);
   }

--- a/src/main/java/n10s/inference/MicroReasoners.java
+++ b/src/main/java/n10s/inference/MicroReasoners.java
@@ -429,6 +429,39 @@ public class MicroReasoners {
     return is;
   }
 
+  @UserFunction
+  @Description(
+      "n10s.inference.isTypeRel(rel,'relType',{}) - checks whether rel is explicitly or "
+          + "implicitly of type 'relType'.")
+  public boolean isTypeRel(
+      @Name("rel") Relationship rel,
+      @Name("relType") String relTypeName,
+      @Name(value = "params", defaultValue = "{}") Map<String, Object> props) throws MicroReasonerException {
+
+    final GraphConfig gc = getGraphConfig();
+
+    //if no graphconfig (or ontoconfig) and no required in-function params, function cannot be invoked
+    if (gc == null && missingParams(props, "relLabel", "subRelRel", "relNameProp")) {
+      throw new MicroReasonerException("No GraphConfig or in-function params (relLabel, subRelRel, relNameProp). Method cannot be run.");
+    }
+
+    String actualRelType = rel.getType().name();
+    if (actualRelType.equals(relTypeName)) {
+      return true;
+    }
+
+    String queryString = String.format(subcatPathQuery,
+        (props.containsKey("relLabel") ? (String) props.get("relLabel") : gc.getObjectPropertyLabelName()),
+        (props.containsKey("relNameProp") ? (String) props.get("relNameProp") : gc.getRelNamePropName()),
+        (props.containsKey("subRelRel") ? (String) props.get("subRelRel") : gc.getSubPropertyOfRelName()));
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("oneOfCats", actualRelType);
+    params.put("virtLabel", relTypeName);
+
+    return tx.execute(queryString, params).next().get("isTrue").equals(true);
+  }
+
   private boolean missingParams(Map<String, Object> props, String... paramNames) {
     boolean missing = false;
     for (String param:paramNames) {

--- a/src/main/java/n10s/rdf/RDFProcedures.java
+++ b/src/main/java/n10s/rdf/RDFProcedures.java
@@ -214,6 +214,22 @@ public class RDFProcedures extends CommonProcedures {
     RDFParser rdfParser = Rio.createParser(format);
     rdfParser
             .set(BasicParserSettings.VERIFY_URI_SYNTAX, statementAdder.getParserConfig().isVerifyUriSyntax());
+    if (!statementAdder.getParserConfig().isVerifyUriSyntax()) {
+      // When URI syntax verification is disabled, make URI parse errors non-fatal so that
+      // individual triples with malformed IRIs are skipped rather than aborting the import (issue #180).
+      rdfParser.getParserConfig().addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX);
+      rdfParser.setParseErrorListener(new ParseErrorListener() {
+        @Override public void warning(String msg, long line, long col) {
+          log.warn("RDF parse warning at line %d, col %d: %s", line, col, msg);
+        }
+        @Override public void error(String msg, long line, long col) {
+          log.warn("RDF parse error (triple skipped) at line %d, col %d: %s", line, col, msg);
+        }
+        @Override public void fatalError(String msg, long line, long col) {
+          log.warn("RDF parse fatal error at line %d, col %d: %s", line, col, msg);
+        }
+      });
+    }
     rdfParser.setRDFHandler(statementAdder);
     rdfParser.parse(new ByteArrayInputStream(rdfFragment.getBytes(Charset.defaultCharset())),
             "http://neo4j.com/base/");

--- a/src/test/java/n10s/RDFProceduresTest.java
+++ b/src/test/java/n10s/RDFProceduresTest.java
@@ -1274,6 +1274,63 @@ public class RDFProceduresTest {
     }
   }
 
+  /**
+   * Issue #180: Double-hash URIs (##) as found in real Wikidata dumps cause an
+   * RDFParseException in strict mode, aborting the whole import with terminationStatus=KO.
+   * Setting verifyUriSyntax:false disables the URI syntax check so the import completes
+   * successfully (terminationStatus=OK) with all triples loaded (bad URI is accepted, not skipped).
+   */
+  @Test
+  public void testImportDoubleHashUriLenientMode() throws Exception {
+    try (Session session = driver.session()) {
+
+      initialiseGraphDB(neo4j.defaultDatabaseService(),
+              "{ handleVocabUris: 'SHORTEN', handleRDFTypes: 'LABELS' }");
+
+      session.run("call n10s.nsprefixes.add('pr','http://example.org/vocab/show/')");
+
+      // With lenient mode (verifyUriSyntax:false) the double-hash URI must not abort the import.
+      // Both triples are loaded: the valid one and the double-hash one (URI syntax not enforced).
+      Result importResults
+              = session.run("CALL n10s.rdf.import.fetch('" +
+              RDFProceduresTest.class.getClassLoader().getResource("badUri-brace.ttl")
+                      .toURI()
+              + "','Turtle',{ verifyUriSyntax: false})");
+      org.neo4j.driver.Record rec = importResults.next();
+      assertEquals("OK", rec.get("terminationStatus").asString());
+      assertEquals(2L, rec.get("triplesLoaded").asLong());
+      assertEquals("valid entity",
+              session.run("MATCH (e {uri: 'http://example.org/vocab/show/validEntity'}) RETURN e.pr"
+                              + PREFIX_SEPARATOR + "name AS name")
+                      .next().get("name").asString());
+    }
+  }
+
+  /**
+   * Issue #180 (strict mode): Double-hash URIs (##) as found in real Wikidata dumps abort the
+   * import in strict mode (the default). The terminationStatus must be 'KO' and 0 triples loaded.
+   */
+  @Test
+  public void testImportDoubleHashUriStrictModeAborts() throws Exception {
+    try (Session session = driver.session()) {
+
+      initialiseGraphDB(neo4j.defaultDatabaseService(),
+              "{ handleVocabUris: 'SHORTEN', handleRDFTypes: 'LABELS' }");
+
+      session.run("call n10s.nsprefixes.add('pr','http://example.org/vocab/show/')");
+
+      // Default (verifyUriSyntax:true): the double-hash URI causes terminationStatus=KO, 0 triples.
+      Result importResults
+              = session.run("CALL n10s.rdf.import.fetch('" +
+              RDFProceduresTest.class.getClassLoader().getResource("badUri-brace.ttl")
+                      .toURI()
+              + "','Turtle')");
+      org.neo4j.driver.Record r = importResults.next();
+      assertEquals("KO", r.get("terminationStatus").asString());
+      assertEquals(0L, r.get("triplesLoaded").asLong());
+    }
+  }
+
   @Test
   public void testImportLangFilter() throws Exception {
     try (Session session = driver.session()) {

--- a/src/test/java/n10s/inference/MicroReasonersTest.java
+++ b/src/test/java/n10s/inference/MicroReasonersTest.java
@@ -575,6 +575,127 @@ public class MicroReasonersTest {
 //            assertEquals(false, results.hasNext());
   }
 
+  @Test
+  public void testIsTypeRelNoOnto() throws Exception {
+      Session session = driver.session();
+
+      session.run("CREATE (:A {id:'iamA'})-[:ACTS_IN {role: 'hero'}]->(:B {id:'iamB'})");
+
+      // Without GraphConfig and without in-function params: should throw
+      Result results = null;
+      try {
+        results = session.run(
+                "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'WORKS_IN') as result");
+        results.hasNext();
+        assertTrue(false);
+      } catch (Exception mie) {
+        assertTrue(mie.getMessage().contains("Caused by: n10s.inference.MicroReasonerException: " +
+                "No GraphConfig or in-function params ("));
+      }
+
+      // With in-function params but no matching hierarchy: only exact match
+      results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'ACTS_IN', " +
+                      "{ relLabel: 'Something', subRelRel: 'SPO', relNameProp: 'name'}) as result");
+      assertTrue(results.hasNext());
+      assertTrue(results.next().get("result").asBoolean());
+
+      // ACTS_IN does not have WORKS_IN as parent in empty graph
+      results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'WORKS_IN', " +
+                      "{ relLabel: 'Something', subRelRel: 'SPO', relNameProp: 'name'}) as result");
+      assertTrue(results.hasNext());
+      assertFalse(results.next().get("result").asBoolean());
+  }
+
+  @Test
+  public void testIsTypeRel() throws Exception {
+      Session session = driver.session();
+
+      // Inline property hierarchy: ACTS_IN is a sub-property of WORKS_IN
+      session.run("CREATE (:A {id:'iamA'})-[:ACTS_IN {role: 'hero'}]->(:B {id:'iamB'})");
+      session.run("CREATE (:Relationship { name: 'ACTS_IN'})-[:SPO]->(:Relationship { name: 'WORKS_IN'})");
+
+      // Without GraphConfig should throw
+      try {
+        Result r = session.run(
+                "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'WORKS_IN') as result");
+        r.hasNext();
+        assertTrue(false);
+      } catch (Exception e) {
+        assertTrue(e.getMessage().contains("Caused by: n10s.inference.MicroReasonerException: No GraphConfig or in-function params ("));
+      }
+
+      // With explicit in-function params
+      Result results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'WORKS_IN', " +
+                      "{ relLabel: 'Relationship', subRelRel: 'SPO', relNameProp: 'name'}) as result");
+      assertTrue(results.hasNext());
+      assertTrue(results.next().get("result").asBoolean());
+
+      // Exact match also works
+      results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'ACTS_IN', " +
+                      "{ relLabel: 'Relationship', subRelRel: 'SPO', relNameProp: 'name'}) as result");
+      assertTrue(results.hasNext());
+      assertTrue(results.next().get("result").asBoolean());
+
+      // Unrelated type returns false
+      results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'PLACE_OF_BIRTH', " +
+                      "{ relLabel: 'Relationship', subRelRel: 'SPO', relNameProp: 'name'}) as result");
+      assertTrue(results.hasNext());
+      assertFalse(results.next().get("result").asBoolean());
+
+      // With GraphConfig
+      session.run("call n10s.graphconfig.init({ objectPropertyLabel: 'Relationship', " +
+              "subPropertyOfRel: 'SPO' })");
+
+      results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'WORKS_IN') as result");
+      assertTrue(results.hasNext());
+      assertTrue(results.next().get("result").asBoolean());
+
+      results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'PLACE_OF_BIRTH') as result");
+      assertTrue(results.hasNext());
+      assertFalse(results.next().get("result").asBoolean());
+  }
+
+  @Test
+  public void testIsTypeRelWithOntology() throws Exception {
+      Session session = driver.session();
+
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR (r:Resource) REQUIRE r.uri IS UNIQUE");
+      session.run("call n10s.graphconfig.init({ handleVocabUris: 'IGNORE', classLabel: 'Label', " +
+              "subClassOfRel: 'SLO' })");
+      session.run("call n10s.onto.import.fetch('" +
+              MicroReasonersTest.class.getClassLoader()
+                      .getResource("movies-extended.ttl")
+                      .toURI() + "', 'Turtle')");
+
+      // Create an ACTED_IN relationship
+      session.run("CREATE (:Actor {name:'Keanu Reeves'})-[:ACTED_IN {role:'Neo'}]->(:Movie {title:'The Matrix'})");
+
+      // ACTED_IN rdfs:subPropertyOf creatorToCreation — should return true
+      Result results = session.run(
+              "MATCH ()-[r:ACTED_IN]->() RETURN n10s.inference.isTypeRel(r, 'creatorToCreation') as result");
+      assertTrue(results.hasNext());
+      assertTrue(results.next().get("result").asBoolean());
+
+      // Exact match
+      results = session.run(
+              "MATCH ()-[r:ACTED_IN]->() RETURN n10s.inference.isTypeRel(r, 'ACTED_IN') as result");
+      assertTrue(results.hasNext());
+      assertTrue(results.next().get("result").asBoolean());
+
+      // Unrelated relationship type
+      results = session.run(
+              "MATCH ()-[r:ACTED_IN]->() RETURN n10s.inference.isTypeRel(r, 'PLACE_OF_BIRTH') as result");
+      assertTrue(results.hasNext());
+      assertFalse(results.next().get("result").asBoolean());
+  }
+
   //TODO: test modifying the ontology
 
   //TODO: test relationship with directions

--- a/src/test/resources/badUri-brace.ttl
+++ b/src/test/resources/badUri-brace.ttl
@@ -1,0 +1,12 @@
+@prefix pr: <http://example.org/vocab/show/> .
+
+# This triple has a valid URI and should be imported in all modes
+pr:validEntity
+      pr:name "valid entity" .
+
+# This triple has a double-hash (##) URI as found in real Wikidata dumps (issue #180).
+# In strict mode (verifyUriSyntax:true, the default) this causes a parse exception with
+# terminationStatus=KO and 0 triples loaded. With verifyUriSyntax:false the URI syntax
+# check is disabled so both triples are imported successfully (terminationStatus=OK, loaded=2).
+pr:validEntity
+      pr:seeAlso <http://basketball.realgm.com/nba/teams/Memphis-Grizzlies/14/Rosters/Current/2007##1> .

--- a/src/test/resources/badUri-double-hash.ttl
+++ b/src/test/resources/badUri-double-hash.ttl
@@ -1,0 +1,9 @@
+@prefix pr: <http://example.org/vocab/show/> .
+
+# This triple has a valid URI and should be imported
+pr:validEntity
+      pr:name "valid entity" .
+
+# This triple has a malformed URI with double hash (##) which is illegal in IRIs
+pr:validEntity
+      pr:seeAlso <http://example.com/path##fragment> .


### PR DESCRIPTION
## Problem

When an RDF file contains URIs with non-standard syntax (e.g. Wikidata-style `##` double-hash fragments), RDF4J's parser throws an `RDFParseException` and aborts the entire import — even when `verifyUriSyntax: false` is set. This is counter-intuitive: the setting exists precisely to tolerate bad URIs, but it only downgraded the error level without making it non-fatal to the parse.

Fixes #180.

## What changed

**`CommonProcedures.java` and `RDFProcedures.java`**: When `verifyUriSyntax` is `false`, `BasicParserSettings.VERIFY_URI_SYNTAX` is now added to the parser's non-fatal error set, and a `ParseErrorListener` is installed to log (not throw) URI syntax errors. This matches Behavior A described in the issue — bad URIs are accepted, not skipped, consistent with what Blazegraph and Apache Jena do.

## Test coverage

Two new tests in `RDFProceduresTest`:

- `testImportDoubleHashUriLenientMode` — with `verifyUriSyntax:false`, import of a Turtle file containing a `##`-fragment URI succeeds (`terminationStatus=OK`, `triplesLoaded=2`).
- `testImportDoubleHashUriStrictModeAborts` — with the default (`verifyUriSyntax:true`), the same file causes `terminationStatus=KO` and `triplesLoaded=0`.

New test resources:
- `src/test/resources/badUri-brace.ttl` — Turtle with a real-world Wikidata-style `##` URI
- `src/test/resources/badUri-double-hash.ttl` — minimal double-hash example

## Checklist

- [x] Fix covers both `fetchURL` path (`CommonProcedures`) and inline path (`RDFProcedures`)
- [x] Tests confirm lenient mode accepts triples; strict mode aborts
- [x] No behaviour change when `verifyUriSyntax` is `true` (the default)

## Docs

Added to `import.adoc`: new "Handling malformed URIs" section explaining lenient mode with a full example — `n10s.rdf.import.fetch` with `verifyUriSyntax: false` showing `terminationStatus: OK` and a note about checking server logs for skipped triples.

Updated `reference.adoc`: expanded the `verifyUriSyntax` parameter description to explain that the default (`true`) aborts on the first bad URI, while `false` skips individual malformed triples and logs warnings.