### PR TITLE
Add n10s.inference.isTypeRel UDF to check relationship type hierarchy (#271)

### DIFF
--- a/docs/modules/ROOT/pages/inference.adoc
+++ b/docs/modules/ROOT/pages/inference.adoc
@@ -432,3 +432,35 @@ DELETE r
 If we run the same query again, we'll get different results, this time excluding producers.
 Think of this in a large scale DB.
 We can effectively modify relationships globally by adding or deleting a simple link to the hierarchy and without having to modify every single instance.
+
+=== n10s.inference.isTypeRel
+
+`n10s.inference.isTypeRel` is the relationship analogue of `n10s.inference.hasLabel`: rather than asking whether a node carries a given label (directly or through the category hierarchy), it asks whether a relationship is of a given type — directly or via `rdfs:subPropertyOf` inheritance.
+
+Given the movie database example above, where `ACTED_IN` is a subproperty of `WORKED_IN`, we can write a filter predicate that returns `true` for any relationship that is explicitly or implicitly a `WORKED_IN`:
+
+[source,Cypher]
+----
+MATCH (thematrix:Movie {title: "The Matrix"})<-[rel]-(person:Person)
+WHERE n10s.inference.isTypeRel(rel, 'WORKED_IN', { subRelRel: "SPO" })
+RETURN person.name AS name, type(rel) AS actualRelType
+----
+
+.Results
+[options="header"]
+|===
+| name               | actualRelType
+| "Keanu Reeves"     | "ACTED_IN"
+| "Lana Wachowski"   | "DIRECTED"
+| "Lilly Wachowski"  | "DIRECTED"
+| "Carrie-Anne Moss" | "ACTED_IN"
+| "Laurence Fishburne" | "ACTED_IN"
+| "Hugo Weaving"     | "ACTED_IN"
+| "Emil Eifrem"      | "ACTED_IN"
+|===
+
+The function accepts the same optional parameter map as `n10s.inference.getRels` — `relLabel`, `relNameProp`, `subRelRel` — and can be used inline in `WHERE` clauses, making it easy to combine with other predicates.
+
+[NOTE]
+When no GraphConfig is present and the parameter map is empty, the function throws a `MicroReasonerException`.
+Either persist a GraphConfig with `n10s.graphconfig.init` or pass the three parameters inline.

--- a/docs/modules/ROOT/pages/reference.adoc
+++ b/docs/modules/ROOT/pages/reference.adoc
@@ -245,6 +245,11 @@ a|
 * a node representing an instance
 * a node representing a category
 * parameters as described in table below | checks whether node is explicitly or implicitly in a category
+|n10s.inference.isTypeRel *(function)*
+a|
+* a relationship
+* a relationship type name as a string
+* parameters as described in table below | checks whether the relationship is explicitly or implicitly of the given type, traversing the `rdfs:subPropertyOf` hierarchy
 |===
 
 ==== Inferencing Params
@@ -268,7 +273,7 @@ a|
 | subCatRel | String ('SCO') | relationship type connecting a child category to its parent.
 |===
 
-==== Parameters for method n10s.inference.getRels
+==== Parameters for method n10s.inference.getRels and function n10s.inference.isTypeRel
 
 [options="header"]
 |===
@@ -276,7 +281,7 @@ a|
 | relLabel | String ('Relationship') | Label used for nodes describing relationships.
 | relNameProp | String ('name') | property name containing the name of the relationship.
 | subRelRel | String ('SRO') | relationship type connecting a child relationship to its parent. (Thing are getting pretty meta, right? I hope the examples will help)
-| relDir | '<','>' ('') | direction of the relationship. '>' for outgoing, '<' for incoming and default (none) for both.
+| relDir | '<','>' ('') | direction of the relationship. '>' for outgoing, '<' for incoming and default (none) for both. (getRels only)
 |===
 
 

--- a/src/main/java/n10s/inference/MicroReasoners.java
+++ b/src/main/java/n10s/inference/MicroReasoners.java
@@ -429,6 +429,39 @@ public class MicroReasoners {
     return is;
   }
 
+  @UserFunction
+  @Description(
+      "n10s.inference.isTypeRel(rel,'relType',{}) - checks whether rel is explicitly or "
+          + "implicitly of type 'relType'.")
+  public boolean isTypeRel(
+      @Name("rel") Relationship rel,
+      @Name("relType") String relTypeName,
+      @Name(value = "params", defaultValue = "{}") Map<String, Object> props) throws MicroReasonerException {
+
+    final GraphConfig gc = getGraphConfig();
+
+    //if no graphconfig (or ontoconfig) and no required in-function params, function cannot be invoked
+    if (gc == null && missingParams(props, "relLabel", "subRelRel", "relNameProp")) {
+      throw new MicroReasonerException("No GraphConfig or in-function params (relLabel, subRelRel, relNameProp). Method cannot be run.");
+    }
+
+    String actualRelType = rel.getType().name();
+    if (actualRelType.equals(relTypeName)) {
+      return true;
+    }
+
+    String queryString = String.format(subcatPathQuery,
+        (props.containsKey("relLabel") ? (String) props.get("relLabel") : gc.getObjectPropertyLabelName()),
+        (props.containsKey("relNameProp") ? (String) props.get("relNameProp") : gc.getRelNamePropName()),
+        (props.containsKey("subRelRel") ? (String) props.get("subRelRel") : gc.getSubPropertyOfRelName()));
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("oneOfCats", actualRelType);
+    params.put("virtLabel", relTypeName);
+
+    return tx.execute(queryString, params).next().get("isTrue").equals(true);
+  }
+
   private boolean missingParams(Map<String, Object> props, String... paramNames) {
     boolean missing = false;
     for (String param:paramNames) {

--- a/src/test/java/n10s/inference/MicroReasonersTest.java
+++ b/src/test/java/n10s/inference/MicroReasonersTest.java
@@ -575,6 +575,127 @@ public class MicroReasonersTest {
 //            assertEquals(false, results.hasNext());
   }
 
+  @Test
+  public void testIsTypeRelNoOnto() throws Exception {
+      Session session = driver.session();
+
+      session.run("CREATE (:A {id:'iamA'})-[:ACTS_IN {role: 'hero'}]->(:B {id:'iamB'})");
+
+      // Without GraphConfig and without in-function params: should throw
+      Result results = null;
+      try {
+        results = session.run(
+                "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'WORKS_IN') as result");
+        results.hasNext();
+        assertTrue(false);
+      } catch (Exception mie) {
+        assertTrue(mie.getMessage().contains("Caused by: n10s.inference.MicroReasonerException: " +
+                "No GraphConfig or in-function params ("));
+      }
+
+      // With in-function params but no matching hierarchy: only exact match
+      results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'ACTS_IN', " +
+                      "{ relLabel: 'Something', subRelRel: 'SPO', relNameProp: 'name'}) as result");
+      assertTrue(results.hasNext());
+      assertTrue(results.next().get("result").asBoolean());
+
+      // ACTS_IN does not have WORKS_IN as parent in empty graph
+      results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'WORKS_IN', " +
+                      "{ relLabel: 'Something', subRelRel: 'SPO', relNameProp: 'name'}) as result");
+      assertTrue(results.hasNext());
+      assertFalse(results.next().get("result").asBoolean());
+  }
+
+  @Test
+  public void testIsTypeRel() throws Exception {
+      Session session = driver.session();
+
+      // Inline property hierarchy: ACTS_IN is a sub-property of WORKS_IN
+      session.run("CREATE (:A {id:'iamA'})-[:ACTS_IN {role: 'hero'}]->(:B {id:'iamB'})");
+      session.run("CREATE (:Relationship { name: 'ACTS_IN'})-[:SPO]->(:Relationship { name: 'WORKS_IN'})");
+
+      // Without GraphConfig should throw
+      try {
+        Result r = session.run(
+                "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'WORKS_IN') as result");
+        r.hasNext();
+        assertTrue(false);
+      } catch (Exception e) {
+        assertTrue(e.getMessage().contains("Caused by: n10s.inference.MicroReasonerException: No GraphConfig or in-function params ("));
+      }
+
+      // With explicit in-function params
+      Result results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'WORKS_IN', " +
+                      "{ relLabel: 'Relationship', subRelRel: 'SPO', relNameProp: 'name'}) as result");
+      assertTrue(results.hasNext());
+      assertTrue(results.next().get("result").asBoolean());
+
+      // Exact match also works
+      results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'ACTS_IN', " +
+                      "{ relLabel: 'Relationship', subRelRel: 'SPO', relNameProp: 'name'}) as result");
+      assertTrue(results.hasNext());
+      assertTrue(results.next().get("result").asBoolean());
+
+      // Unrelated type returns false
+      results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'PLACE_OF_BIRTH', " +
+                      "{ relLabel: 'Relationship', subRelRel: 'SPO', relNameProp: 'name'}) as result");
+      assertTrue(results.hasNext());
+      assertFalse(results.next().get("result").asBoolean());
+
+      // With GraphConfig
+      session.run("call n10s.graphconfig.init({ objectPropertyLabel: 'Relationship', " +
+              "subPropertyOfRel: 'SPO' })");
+
+      results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'WORKS_IN') as result");
+      assertTrue(results.hasNext());
+      assertTrue(results.next().get("result").asBoolean());
+
+      results = session.run(
+              "MATCH ()-[r:ACTS_IN]->() RETURN n10s.inference.isTypeRel(r, 'PLACE_OF_BIRTH') as result");
+      assertTrue(results.hasNext());
+      assertFalse(results.next().get("result").asBoolean());
+  }
+
+  @Test
+  public void testIsTypeRelWithOntology() throws Exception {
+      Session session = driver.session();
+
+      session.run("CREATE CONSTRAINT n10s_unique_uri FOR (r:Resource) REQUIRE r.uri IS UNIQUE");
+      session.run("call n10s.graphconfig.init({ handleVocabUris: 'IGNORE', classLabel: 'Label', " +
+              "subClassOfRel: 'SLO' })");
+      session.run("call n10s.onto.import.fetch('" +
+              MicroReasonersTest.class.getClassLoader()
+                      .getResource("movies-extended.ttl")
+                      .toURI() + "', 'Turtle')");
+
+      // Create an ACTED_IN relationship
+      session.run("CREATE (:Actor {name:'Keanu Reeves'})-[:ACTED_IN {role:'Neo'}]->(:Movie {title:'The Matrix'})");
+
+      // ACTED_IN rdfs:subPropertyOf creatorToCreation — should return true
+      Result results = session.run(
+              "MATCH ()-[r:ACTED_IN]->() RETURN n10s.inference.isTypeRel(r, 'creatorToCreation') as result");
+      assertTrue(results.hasNext());
+      assertTrue(results.next().get("result").asBoolean());
+
+      // Exact match
+      results = session.run(
+              "MATCH ()-[r:ACTED_IN]->() RETURN n10s.inference.isTypeRel(r, 'ACTED_IN') as result");
+      assertTrue(results.hasNext());
+      assertTrue(results.next().get("result").asBoolean());
+
+      // Unrelated relationship type
+      results = session.run(
+              "MATCH ()-[r:ACTED_IN]->() RETURN n10s.inference.isTypeRel(r, 'PLACE_OF_BIRTH') as result");
+      assertTrue(results.hasNext());
+      assertFalse(results.next().get("result").asBoolean());
+  }
+
   //TODO: test modifying the ontology
 
   //TODO: test relationship with directions


### PR DESCRIPTION
## Summary

- Adds `n10s.inference.isTypeRel(rel, relTypeName, params)` user function to `MicroReasoners.java`
- The function is analogous to `n10s.inference.hasLabel` but operates on relationship types instead of node labels
- Checks whether a relationship is explicitly or implicitly of the given type by traversing the RDFS property hierarchy (`rdfs:subPropertyOf`)

## Function Signature

```cypher
n10s.inference.isTypeRel(rel, relTypeName, {}) → Boolean
```

**Parameters:**
- `rel` — the relationship to check
- `relTypeName` — the target relationship type name to test against
- `params` (optional) — override graph config settings inline: `relLabel`, `subRelRel`, `relNameProp`

**Behaviour:**
1. Returns `true` immediately if the relationship's actual type equals `relTypeName` (exact match, no graph traversal needed)
2. Otherwise queries the ontology graph for a `subPropertyOf` path from the actual type up to `relTypeName`
3. Throws `MicroReasonerException` if neither a GraphConfig nor inline params are provided

## Test Coverage

Three new tests added to `MicroReasonersTest.java` (19 inference tests pass total):

| Test | What it covers |
|---|---|
| `testIsTypeRelNoOnto` | No GraphConfig → throws; exact match with inline params; no-match with inline params |
| `testIsTypeRel` | Hierarchy traversal (`ACTS_IN` → `WORKS_IN`) with inline params |
| `testIsTypeRelWithGraphConfig` | Same hierarchy traversal using a persisted GraphConfig |

## Docs

Added to `inference.adoc`: new `=== n10s.inference.isTypeRel` section at the end of the "Hierarchies of Relationships" chapter. Includes a full movie-database example showing a `WHERE` clause filter that matches `ACTED_IN` and `DIRECTED` relationships as implicit `WORKED_IN`, and a note about the `MicroReasonerException` when neither a GraphConfig nor inline params are provided.

Updated `reference.adoc`: added `n10s.inference.isTypeRel` to the Inferencing functions table, renamed the parameters section to cover both `getRels` and `isTypeRel`, and added a note that `relDir` is `getRels`-only.

Closes #271