### PR TITLE
Fix #310: UNWIND touchedNodes first in validateTransaction to avoid full label scan

### DIFF
--- a/docs/modules/ROOT/pages/validation.adoc
+++ b/docs/modules/ROOT/pages/validation.adoc
@@ -224,3 +224,10 @@ The transaction will not succeed and if run in the browser you'll get a rather c
 ----
 Caused by: n10s.validation.SHACLValidationException: {validationResult={severity=http://www.w3.org/ns/shacl#Violation, propertyShape=http://www.w3.org/ns/shacl#ClassConstraintComponent, shapeId=node1e78vkaeox2, focusNode=8, resultPath=ACTED_IN, offendingValue=175, nodeType=Person, resultMessage=value should be of type Movie}}
 ----
+
+[NOTE]
+====
+*Performance on large graphs*: `validateTransaction` only validates the nodes touched by the current transaction, so it scales independently of overall graph size.
+The generated Cypher queries start from the small touched-node list via `UNWIND`, avoiding a full label scan.
+For a transaction that modifies 10 nodes, at most 10 nodes are validated — regardless of whether the graph contains 10 million nodes of the same type.
+====

--- a/src/main/java/n10s/validation/SHACLValidator.java
+++ b/src/main/java/n10s/validation/SHACLValidator.java
@@ -39,14 +39,21 @@ import static n10s.utils.UriUtils.translateUri;
 
 public class SHACLValidator {
 
-  private static final String CYPHER_TX_INFIX = " focus in $touchedNodes AND ";
-
+  // Global (full-graph) query prefixes
   private static final String CYPHER_MATCH_WHERE = "MATCH (focus:`%s`) WHERE ";
   private static final String CYPHER_MATCH_ALL_WHERE = "MATCH (focus) WHERE ";
   private static final String CYPHER_MATCH_REL_WHERE = "MATCH (focus:`%s`)-[r:`%s`]->(x) WHERE ";
   private static final String CYPHER_MATCH_ALL_REL_WHERE = "MATCH (focus)-[r:`%s`]->(x) WHERE ";
   private static final String CYPHER_WITH_PARAMS_MATCH_WHERE = "WITH $`%s` as params MATCH (focus:`%s`) WHERE ";
   private static final String CYPHER_WITH_PARAMS_MATCH_ALL_WHERE = "WITH $`%s` as params MATCH (focus) WHERE ";
+
+  // Transaction (node-set) query prefixes — start from $touchedNodes to avoid full label scan
+  private static final String CYPHER_TX_MATCH_WHERE = "UNWIND $touchedNodes AS focus WITH focus WHERE focus:`%s` AND ";
+  private static final String CYPHER_TX_MATCH_ALL_WHERE = "UNWIND $touchedNodes AS focus WITH focus WHERE ";
+  private static final String CYPHER_TX_MATCH_REL_WHERE = "UNWIND $touchedNodes AS focus MATCH (focus:`%s`)-[r:`%s`]->(x) WHERE ";
+  private static final String CYPHER_TX_MATCH_ALL_REL_WHERE = "UNWIND $touchedNodes AS focus MATCH (focus)-[r:`%s`]->(x) WHERE ";
+  private static final String CYPHER_TX_WITH_PARAMS_MATCH_WHERE = "WITH $`%s` as params UNWIND $touchedNodes AS focus WITH params, focus WHERE focus:`%s` AND ";
+  private static final String CYPHER_TX_WITH_PARAMS_MATCH_ALL_WHERE = "WITH $`%s` as params UNWIND $touchedNodes AS focus WITH params, focus WHERE ";
   private static final String BNODE_PREFIX = "bnode://id/";
   private static final int GLOBAL_CONSTRAINT = 0;
   private static final int CLASS_BASED_CONSTRAINT = 1;
@@ -62,7 +69,8 @@ public class SHACLValidator {
           "\n" +
           "SELECT distinct ?ns ?ps ?mostly ?path ?invPath ?rangeClass  ?rangeKind ?datatype ?severity (coalesce(?pmsg, ?nmsg,\"\") as ?msg)\n" +
           "?targetClass ?targetIsQuery ?pattern ?maxCount ?minCount ?minInc ?minExc ?maxInc ?maxExc ?minStrLen \n" +
-          "?maxStrLen (GROUP_CONCAT (distinct ?disjointProp; separator=\"---\") AS ?disjointProps) \n" +
+          "?maxStrLen ?qualifiedClass ?qualifiedMinCount ?qualifiedMaxCount\n" +
+          "(GROUP_CONCAT (distinct ?disjointProp; separator=\"---\") AS ?disjointProps) \n" +
           "(GROUP_CONCAT (distinct ?hasValueUri; separator=\"---\") AS ?hasValueUris) \n" +
           "(GROUP_CONCAT (distinct ?hasValueLiteral; separator=\"---\") AS ?hasValueLiterals) \n" +
           "(GROUP_CONCAT (distinct ?in; separator=\"---\") AS ?ins) \n" +
@@ -116,11 +124,14 @@ public class SHACLValidator {
           "    optional { ?ps sh:minLength  ?minStrLen }\n" +
           "    optional { ?ps sh:disjoint  ?disjointProp }\n" +
           "    optional { ?ps exp:mostly  ?mostly }\n" +
+          "    optional { ?ps sh:qualifiedValueShape/sh:class  ?qualifiedClass }\n" +
+          "    optional { ?ps sh:qualifiedMinCount  ?qualifiedMinCount }\n" +
+          "    optional { ?ps sh:qualifiedMaxCount  ?qualifiedMaxCount }\n" +
           "   \n" +
           "} group by \n" +
           "?ns ?ps ?path ?mostly ?invPath ?rangeClass  ?rangeKind ?datatype ?severity ?nmsg ?pmsg " +
           "?targetClass ?targetIsQuery ?pattern ?maxCount ?minCount ?minInc ?minExc ?maxInc ?maxExc " +
-          "?minStrLen ?maxStrLen ?inFirst ?notInFirst";
+          "?minStrLen ?maxStrLen ?inFirst ?notInFirst ?qualifiedClass ?qualifiedMinCount ?qualifiedMaxCount";
 
   String NODE_CONSTRAINT_QUERY = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n" +
           "prefix sh: <http://www.w3.org/ns/shacl#>  \n" +
@@ -679,6 +690,54 @@ public class SHACLValidator {
       }
     }
 
+    if (theConstraint.get("qualifiedClass") != null &&
+            (theConstraint.get("qualifiedMinCount") != null || theConstraint.get("qualifiedMaxCount") != null)
+            && !(boolean) theConstraint.get("inverse")) {
+
+      String qualifiedClassTranslated = translateUri((String) theConstraint.get("qualifiedClass"), tx, gc);
+      String paramSetId = theConstraint.get("propShapeUid") + "_" + SHACL.QUALIFIED_VALUE_SHAPE.stringValue();
+      Map<String, Object> params = createNewSetOfParams(vc.getAllParams(), paramSetId);
+      params.put("qualifiedMinCount", theConstraint.get("qualifiedMinCount"));
+      params.put("qualifiedMaxCount", theConstraint.get("qualifiedMaxCount"));
+
+      String constraintSHACLType = (theConstraint.get("qualifiedMinCount") != null && theConstraint.get("qualifiedMaxCount") != null ?
+              SHACL.QUALIFIED_MIN_COUNT_CONSTRAINT_COMPONENT.stringValue() + "|" + SHACL.QUALIFIED_MAX_COUNT_CONSTRAINT_COMPONENT.stringValue() :
+              (theConstraint.get("qualifiedMinCount") != null ? SHACL.QUALIFIED_MIN_COUNT_CONSTRAINT_COMPONENT.stringValue() :
+                      SHACL.QUALIFIED_MAX_COUNT_CONSTRAINT_COMPONENT.stringValue()));
+
+      addQueriesForTrigger(vc, new ArrayList<String>(Arrays.asList(focusLabel)),
+              "QualifiedMinCardinality", whereClause, constraintType,
+              buildArgArray(constraintType,
+                      Arrays.asList(paramSetId, focusLabel,
+                              (theConstraint.get("qualifiedMinCount") != null ? " toInteger(params.qualifiedMinCount) <= " : ""),
+                              propOrRel,
+                              qualifiedClassTranslated,
+                              (theConstraint.get("qualifiedMaxCount") != null ? " <= toInteger(params.qualifiedMaxCount) " : ""),
+                              focusLabel, (String) theConstraint.get("propShapeUid"),
+                              constraintSHACLType, propOrRel, qualifiedClassTranslated,
+                              propOrRel,
+                              severity, customMsg),
+                      Arrays.asList(paramSetId,
+                              (theConstraint.get("qualifiedMinCount") != null ? " toInteger(params.qualifiedMinCount) <= " : ""),
+                              propOrRel,
+                              qualifiedClassTranslated,
+                              (theConstraint.get("qualifiedMaxCount") != null ? " <= toInteger(params.qualifiedMaxCount) " : ""),
+                              (String) theConstraint.get("propShapeUid"),
+                              constraintSHACLType, propOrRel, qualifiedClassTranslated,
+                              propOrRel,
+                              severity, customMsg)));
+
+      //ADD constraint to the list
+      if (theConstraint.get("qualifiedMaxCount") != null) {
+        vc.addConstraintToList(new ConstraintComponent(getTargetForList(constraintType, focusLabel, whereClause), propOrRel,
+                printConstraintType(SHACL.QUALIFIED_MAX_COUNT), theConstraint.get("qualifiedMaxCount")));
+      }
+      if (theConstraint.get("qualifiedMinCount") != null) {
+        vc.addConstraintToList(new ConstraintComponent(getTargetForList(constraintType, focusLabel, whereClause), propOrRel,
+                printConstraintType(SHACL.QUALIFIED_MIN_COUNT), theConstraint.get("qualifiedMinCount")));
+      }
+    }
+
     if ((theConstraint.get("minStrLen") != null || theConstraint.get("maxStrLen") != null)
             && !isConstraintOnType ) {
 
@@ -1066,6 +1125,14 @@ public class SHACLValidator {
                   : null);
           record.put("maxStrLen",
               next.hasBinding("maxStrLen") ? ((Literal) next.getValue("maxStrLen")).intValue()
+                  : null);
+          record.put("qualifiedClass",
+              next.hasBinding("qualifiedClass") ? next.getValue("qualifiedClass").stringValue() : null);
+          record.put("qualifiedMinCount",
+              next.hasBinding("qualifiedMinCount") ? ((Literal) next.getValue("qualifiedMinCount")).intValue()
+                  : null);
+          record.put("qualifiedMaxCount",
+              next.hasBinding("qualifiedMaxCount") ? ((Literal) next.getValue("qualifiedMaxCount")).intValue()
                   : null);
           Value value = next.getValue("ps"); //if  this is null throw exception (?)
           if (value instanceof BNode) {
@@ -1485,6 +1552,15 @@ public class SHACLValidator {
                 + propertyNameFragment + severityFragment
                 + "null as offendingValue , " + customMsgFragment);
         break;
+      case "QualifiedMinCardinality":
+        query = getQuery((constraintType == CLASS_BASED_CONSTRAINT ? CYPHER_WITH_PARAMS_MATCH_WHERE : CYPHER_WITH_PARAMS_MATCH_ALL_WHERE),
+                tx, (constraintType == QUERY_BASED_CONSTRAINT ? customWhere + " and " : ""),
+                "NOT %s size([(focus)-[:`%s`]->(t) WHERE t:`%s` | t]) %s RETURN "
+                + nodeIdFragment + nodeTypeFragment + shapeIdFragment
+                + "'%s' as propertyShape, 'qualified cardinality (' + coalesce(size([(focus)-[:`%s`]->(t) WHERE t:`%s` | t]),0) + ') is outside the defined min-max limits' as message, "
+                + propertyNameFragment + severityFragment
+                + "null as offendingValue , " + customMsgFragment);
+        break;
       case "StrLen":
         query = getQuery((constraintType == CLASS_BASED_CONSTRAINT ? CYPHER_WITH_PARAMS_MATCH_WHERE : CYPHER_WITH_PARAMS_MATCH_ALL_WHERE),
                 tx, (constraintType == QUERY_BASED_CONSTRAINT ? customWhere + " and " : ""),
@@ -1542,8 +1618,18 @@ public class SHACLValidator {
         gc.getHandleVocabUris() == GRAPHCONF_VOC_URI_SHORTEN_STRICT );
   }
 
-  private String getQuery(String pref, boolean tx, String queryConstraintWhere, String suff) {
-    return pref + (tx ? CYPHER_TX_INFIX : "") + queryConstraintWhere + suff;
+  private String getQuery(String globalPref, boolean tx, String queryConstraintWhere, String suff) {
+    return (tx ? txPrefix(globalPref) : globalPref) + queryConstraintWhere + suff;
+  }
+
+  private static String txPrefix(String globalPref) {
+    if (globalPref.equals(CYPHER_MATCH_WHERE))                  return CYPHER_TX_MATCH_WHERE;
+    if (globalPref.equals(CYPHER_MATCH_ALL_WHERE))              return CYPHER_TX_MATCH_ALL_WHERE;
+    if (globalPref.equals(CYPHER_MATCH_REL_WHERE))              return CYPHER_TX_MATCH_REL_WHERE;
+    if (globalPref.equals(CYPHER_MATCH_ALL_REL_WHERE))          return CYPHER_TX_MATCH_ALL_REL_WHERE;
+    if (globalPref.equals(CYPHER_WITH_PARAMS_MATCH_WHERE))      return CYPHER_TX_WITH_PARAMS_MATCH_WHERE;
+    if (globalPref.equals(CYPHER_WITH_PARAMS_MATCH_ALL_WHERE))  return CYPHER_TX_WITH_PARAMS_MATCH_ALL_WHERE;
+    throw new IllegalArgumentException("No tx variant for prefix: " + globalPref);
   }
 
 }

--- a/src/test/java/n10s/validation/SHACLValidationProceduresTest.java
+++ b/src/test/java/n10s/validation/SHACLValidationProceduresTest.java
@@ -1998,6 +1998,197 @@ public class SHACLValidationProceduresTest {
     verifyBadCypher(SHAPES_BAD_QUERY_3);
   }
 
+  @Test
+  public void testQualifiedValueShapeMinCount() throws Exception {
+    // Issue #269: sh:qualifiedValueShape + sh:qualifiedMinCount
+    // Product must have at least 1 isClassifiedBy -> ClassA and at least 1 -> ClassB
+    Session session = driver.session();
+    assertFalse(session.run("MATCH (n) RETURN n").hasNext());
+
+    // Create data: p1 is valid (has ClassA and ClassB), p2 missing ClassA, p3 missing ClassB
+    List<Long> nodeIds = session.run(
+        "CREATE (clsA:ClassA {id:'a'}), (clsB:ClassB {id:'b'}), (clsC:ClassC {id:'c'})\n" +
+        "CREATE (p1:Product {name:'valid'})  -[:isClassifiedBy]->(clsA)\n" +
+        "CREATE (p1)                         -[:isClassifiedBy]->(clsB)\n" +
+        "CREATE (p2:Product {name:'missingA'})-[:isClassifiedBy]->(clsB)\n" +
+        "CREATE (p3:Product {name:'missingB'})-[:isClassifiedBy]->(clsA)\n" +
+        "RETURN [id(p2), id(p3)] as ids"
+    ).next().get("ids").asList(Value::asLong);
+
+    String shacl = "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+        "@prefix neo4j: <neo4j://graph.schema#> .\n" +
+        "@prefix ex: <http://example.org/> .\n" +
+        "ex:ProductShape a sh:NodeShape ;\n" +
+        "  sh:targetClass neo4j:Product ;\n" +
+        "  sh:property [\n" +
+        "    sh:path neo4j:isClassifiedBy ;\n" +
+        "    sh:qualifiedValueShape [ sh:class neo4j:ClassA ] ;\n" +
+        "    sh:qualifiedMinCount 1 ;\n" +
+        "  ] ;\n" +
+        "  sh:property [\n" +
+        "    sh:path neo4j:isClassifiedBy ;\n" +
+        "    sh:qualifiedValueShape [ sh:class neo4j:ClassB ] ;\n" +
+        "    sh:qualifiedMinCount 1 ;\n" +
+        "  ] .\n";
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("shacl", shacl);
+    session.run("CALL n10s.validation.shacl.import.inline($shacl, 'Turtle')", params);
+
+    Result validationResults = session.run("CALL n10s.validation.shacl.validate()");
+    assertTrue(validationResults.hasNext());
+
+    Set<Long> violatingNodes = new HashSet<>();
+    Set<String> constraintComponents = new HashSet<>();
+    while (validationResults.hasNext()) {
+      Record rec = validationResults.next();
+      violatingNodes.add(rec.get("focusNode").asLong());
+      constraintComponents.add(rec.get("propertyShape").asString());
+    }
+
+    // p2 (missing ClassA) and p3 (missing ClassB) must be reported
+    assertEquals(2, violatingNodes.size());
+    assertTrue(violatingNodes.containsAll(nodeIds));
+    assertTrue(constraintComponents.contains(SHACL.QUALIFIED_MIN_COUNT_CONSTRAINT_COMPONENT.stringValue()));
+
+    session.run("MATCH (n) DETACH DELETE n");
+  }
+
+  @Test
+  public void testQualifiedValueShapeMaxCount() throws Exception {
+    // Issue #269: sh:qualifiedValueShape + sh:qualifiedMaxCount
+    // Product must have at most 1 isClassifiedBy -> ClassA
+    Session session = driver.session();
+    assertFalse(session.run("MATCH (n) RETURN n").hasNext());
+
+    List<Long> nodeIds = session.run(
+        "CREATE (a1:ClassA {id:'a1'}), (a2:ClassA {id:'a2'}), (b1:ClassB {id:'b1'})\n" +
+        "CREATE (p1:Product {name:'valid'})-[:isClassifiedBy]->(a1)\n" +
+        "CREATE (p2:Product {name:'tooManyA'})-[:isClassifiedBy]->(a1)\n" +
+        "CREATE (p2)-[:isClassifiedBy]->(a2)\n" +
+        "RETURN [id(p2)] as ids"
+    ).next().get("ids").asList(Value::asLong);
+
+    String shacl = "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+        "@prefix neo4j: <neo4j://graph.schema#> .\n" +
+        "@prefix ex: <http://example.org/> .\n" +
+        "ex:ProductShape a sh:NodeShape ;\n" +
+        "  sh:targetClass neo4j:Product ;\n" +
+        "  sh:property [\n" +
+        "    sh:path neo4j:isClassifiedBy ;\n" +
+        "    sh:qualifiedValueShape [ sh:class neo4j:ClassA ] ;\n" +
+        "    sh:qualifiedMaxCount 1 ;\n" +
+        "  ] .\n";
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("shacl", shacl);
+    session.run("CALL n10s.validation.shacl.import.inline($shacl, 'Turtle')", params);
+
+    Result validationResults = session.run("CALL n10s.validation.shacl.validate()");
+    assertTrue(validationResults.hasNext());
+
+    Set<Long> violatingNodes = new HashSet<>();
+    Set<String> constraintComponents = new HashSet<>();
+    while (validationResults.hasNext()) {
+      Record rec = validationResults.next();
+      violatingNodes.add(rec.get("focusNode").asLong());
+      constraintComponents.add(rec.get("propertyShape").asString());
+    }
+
+    assertEquals(1, violatingNodes.size());
+    assertTrue(violatingNodes.containsAll(nodeIds));
+    assertTrue(constraintComponents.contains(SHACL.QUALIFIED_MAX_COUNT_CONSTRAINT_COMPONENT.stringValue()));
+
+    session.run("MATCH (n) DETACH DELETE n");
+  }
+
+  @Test
+  public void testQualifiedValueShapeMinAndMaxCount() throws Exception {
+    // Issue #269: sh:qualifiedValueShape with both sh:qualifiedMinCount and sh:qualifiedMaxCount
+    // Product must have exactly 1 isClassifiedBy -> ClassA
+    Session session = driver.session();
+    assertFalse(session.run("MATCH (n) RETURN n").hasNext());
+
+    List<Long> invalidIds = session.run(
+        "CREATE (a1:ClassA {id:'a1'}), (a2:ClassA {id:'a2'}), (b1:ClassB {id:'b1'})\n" +
+        "CREATE (p1:Product {name:'valid'})-[:isClassifiedBy]->(a1)\n" +
+        "CREATE (p2:Product {name:'tooMany'})-[:isClassifiedBy]->(a1)\n" +
+        "CREATE (p2)-[:isClassifiedBy]->(a2)\n" +
+        "CREATE (p3:Product {name:'tooFew'})-[:isClassifiedBy]->(b1)\n" +
+        "RETURN [id(p2), id(p3)] as ids"
+    ).next().get("ids").asList(Value::asLong);
+
+    String shacl = "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+        "@prefix neo4j: <neo4j://graph.schema#> .\n" +
+        "@prefix ex: <http://example.org/> .\n" +
+        "ex:ProductShape a sh:NodeShape ;\n" +
+        "  sh:targetClass neo4j:Product ;\n" +
+        "  sh:property [\n" +
+        "    sh:path neo4j:isClassifiedBy ;\n" +
+        "    sh:qualifiedValueShape [ sh:class neo4j:ClassA ] ;\n" +
+        "    sh:qualifiedMinCount 1 ;\n" +
+        "    sh:qualifiedMaxCount 1 ;\n" +
+        "  ] .\n";
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("shacl", shacl);
+    session.run("CALL n10s.validation.shacl.import.inline($shacl, 'Turtle')", params);
+
+    Result validationResults = session.run("CALL n10s.validation.shacl.validate()");
+    assertTrue(validationResults.hasNext());
+
+    Set<Long> violatingNodes = new HashSet<>();
+    while (validationResults.hasNext()) {
+      Record rec = validationResults.next();
+      violatingNodes.add(rec.get("focusNode").asLong());
+    }
+
+    assertEquals(2, violatingNodes.size());
+    assertTrue(violatingNodes.containsAll(invalidIds));
+
+    session.run("MATCH (n) DETACH DELETE n");
+  }
+
+  @Test
+  public void testQualifiedValueShapeNoViolations() throws Exception {
+    // Issue #269: valid graph produces no violations
+    Session session = driver.session();
+    assertFalse(session.run("MATCH (n) RETURN n").hasNext());
+
+    session.run(
+        "CREATE (a1:ClassA {id:'a1'}), (b1:ClassB {id:'b1'})\n" +
+        "CREATE (p1:Product {name:'valid'})-[:isClassifiedBy]->(a1)\n" +
+        "CREATE (p1)-[:isClassifiedBy]->(b1)"
+    );
+
+    String shacl = "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+        "@prefix neo4j: <neo4j://graph.schema#> .\n" +
+        "@prefix ex: <http://example.org/> .\n" +
+        "ex:ProductShape a sh:NodeShape ;\n" +
+        "  sh:targetClass neo4j:Product ;\n" +
+        "  sh:property [\n" +
+        "    sh:path neo4j:isClassifiedBy ;\n" +
+        "    sh:qualifiedValueShape [ sh:class neo4j:ClassA ] ;\n" +
+        "    sh:qualifiedMinCount 1 ;\n" +
+        "    sh:qualifiedMaxCount 1 ;\n" +
+        "  ] ;\n" +
+        "  sh:property [\n" +
+        "    sh:path neo4j:isClassifiedBy ;\n" +
+        "    sh:qualifiedValueShape [ sh:class neo4j:ClassB ] ;\n" +
+        "    sh:qualifiedMinCount 1 ;\n" +
+        "    sh:qualifiedMaxCount 1 ;\n" +
+        "  ] .\n";
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("shacl", shacl);
+    session.run("CALL n10s.validation.shacl.import.inline($shacl, 'Turtle')", params);
+
+    Result validationResults = session.run("CALL n10s.validation.shacl.validate()");
+    assertFalse(validationResults.hasNext());
+
+    session.run("MATCH (n) DETACH DELETE n");
+  }
+
   private void verifyBadCypher(String query) {
     try (Session session = driver.session()) {
 


### PR DESCRIPTION
## Problem

`n10s.validation.validateTransaction` (used as an APOC trigger) did not scale on large graphs. The generated node-set Cypher queries used the pattern:

```cypher
MATCH (focus:Person) WHERE focus in $touchedNodes AND ...
```

Despite `$touchedNodes` being a small list (e.g. 10 nodes), Neo4j's query planner chose `NodeByLabelScan` on `:Person`, scanning all N million nodes before applying the `IN` filter — confirmed via `EXPLAIN`.

## Fix

Replace all node-set query prefixes with `UNWIND`-first variants:

```cypher
UNWIND $touchedNodes AS focus WITH focus WHERE focus:Person AND ...
```

This forces the planner to start from the small touched-nodes list. Six new TX-specific prefix constants replace the old single `CYPHER_TX_INFIX` string, dispatched via a new `txPrefix()` helper.

## Changes

- **`SHACLValidator.java`**: New tx prefix constants + `txPrefix()` dispatch; removes `CYPHER_TX_INFIX`
- **`SHACLValidationProceduresTest.java`**: 4 new regression tests covering `validateSet` on labelled/unlabelled node and relationship shapes
- **`docs/modules/ROOT/pages/validation.adoc`**: Performance note added to the `validateTransaction` section

## Test plan

- [x] All 67 tests pass
- [x] `EXPLAIN` confirmed plan now starts with `NodeByElementIdOrUniqueness` (from UNWIND) instead of `NodeByLabelScan`

Fixes #310