### PR TITLE
Fix #269: add sh:qualifiedValueShape support with sh:qualifiedMinCount / sh:qualifiedMaxCount

### DIFF
--- a/docs/modules/ROOT/pages/validation.adoc
+++ b/docs/modules/ROOT/pages/validation.adoc
@@ -185,6 +185,56 @@ The result would be a reduced version of what we got when run on the whole graph
 ----
 
 
+[[QualifiedValueShape]]
+=== Qualified cardinality constraints (sh:qualifiedValueShape)
+
+Use `sh:qualifiedValueShape` together with `sh:qualifiedMinCount` and/or `sh:qualifiedMaxCount` when you need to count only the relationships that point to nodes of a *specific class*, rather than all relationships on a path.
+
+For example, the following shape requires each `Person` to have at least 1 and at most 3 `KNOWS` relationships whose target carries the `Employee` label:
+
+[source, Turtle]
+----
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix neo4j: <neo4j://graph.schema#> .
+
+neo4j:PersonShape a sh:NodeShape ;
+  sh:targetClass neo4j:Person ;
+  sh:property [
+    sh:path neo4j:KNOWS ;
+    sh:qualifiedValueShape [ sh:class neo4j:Employee ] ;
+    sh:qualifiedMinCount 1 ;
+    sh:qualifiedMaxCount 3 ;
+  ] .
+----
+
+Load and validate as usual:
+
+[source, cypher]
+----
+// Load the constraint
+CALL n10s.validation.shacl.import.inline('
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix neo4j: <neo4j://graph.schema#> .
+
+neo4j:PersonShape a sh:NodeShape ;
+  sh:targetClass neo4j:Person ;
+  sh:property [
+    sh:path neo4j:KNOWS ;
+    sh:qualifiedValueShape [ sh:class neo4j:Employee ] ;
+    sh:qualifiedMinCount 1 ;
+    sh:qualifiedMaxCount 3 ;
+  ] .
+', 'Turtle')
+
+// Run validation
+CALL n10s.validation.shacl.validate()
+YIELD focusNode, nodeType, propertyShape, offendingValue, resultPath, severity
+RETURN focusNode, nodeType, propertyShape, offendingValue, resultPath, severity
+----
+
+`KNOWS` relationships to nodes that do *not* carry the `Employee` label are ignored by the count.
+Both `sh:qualifiedMinCount` and `sh:qualifiedMaxCount` are optional — you can specify either or both.
+
 === Validating transactions
 The validations can also be run in the context of a transaction (in the form a trigger) in a way that if the validation returns a non empty result, the transaction is rolled back.
 This can be useful if we want to prevent getting the graph in a state that violates our model constraints. For this mode of operation we'll use the `validateTransaction` variant.

--- a/src/main/java/n10s/validation/SHACLValidator.java
+++ b/src/main/java/n10s/validation/SHACLValidator.java
@@ -69,6 +69,7 @@ public class SHACLValidator {
           "(GROUP_CONCAT (distinct ?notIn; separator=\"---\") AS ?notins) \n" +
           "(isLiteral(?inFirst) as ?isliteralIns)\n" +
           "(isLiteral(?notInFirst) as ?isliteralNotIns)\n" +
+          "?qualifiedClass ?qualifiedMinCount ?qualifiedMaxCount\n" +
           "{ ?ns a ?shapeOrNodeShape ;\n" +
           "     sh:node?/sh:property ?ps .\n" +
           "  filter ( ?shapeOrNodeShape = sh:Shape || ?shapeOrNodeShape = sh:NodeShape )\n" +
@@ -116,11 +117,14 @@ public class SHACLValidator {
           "    optional { ?ps sh:minLength  ?minStrLen }\n" +
           "    optional { ?ps sh:disjoint  ?disjointProp }\n" +
           "    optional { ?ps exp:mostly  ?mostly }\n" +
+          "    optional { ?ps sh:qualifiedValueShape/sh:class ?qualifiedClass }\n" +
+          "    optional { ?ps sh:qualifiedMinCount  ?qualifiedMinCount }\n" +
+          "    optional { ?ps sh:qualifiedMaxCount  ?qualifiedMaxCount }\n" +
           "   \n" +
           "} group by \n" +
           "?ns ?ps ?path ?mostly ?invPath ?rangeClass  ?rangeKind ?datatype ?severity ?nmsg ?pmsg " +
           "?targetClass ?targetIsQuery ?pattern ?maxCount ?minCount ?minInc ?minExc ?maxInc ?maxExc " +
-          "?minStrLen ?maxStrLen ?inFirst ?notInFirst";
+          "?minStrLen ?maxStrLen ?inFirst ?notInFirst ?qualifiedClass ?qualifiedMinCount ?qualifiedMaxCount";
 
   String NODE_CONSTRAINT_QUERY = "PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>\n" +
           "prefix sh: <http://www.w3.org/ns/shacl#>  \n" +
@@ -880,6 +884,51 @@ public class SHACLValidator {
 
     }
 
+    if (theConstraint.get("qualifiedClass") != null &&
+        (theConstraint.get("qualifiedMinCount") != null || theConstraint.get("qualifiedMaxCount") != null)) {
+
+      String qualifiedClassLabel = translateUri((String) theConstraint.get("qualifiedClass"), tx, gc);
+
+      String paramSetId =
+              theConstraint.get("propShapeUid") + "_" + SHACL.QUALIFIED_VALUE_SHAPE.stringValue();
+      Map<String, Object> params = createNewSetOfParams(vc.getAllParams(), paramSetId);
+      params.put("qualifiedMinCount", theConstraint.get("qualifiedMinCount"));
+      params.put("qualifiedMaxCount", theConstraint.get("qualifiedMaxCount"));
+
+      String constraintSHACLType = (theConstraint.get("qualifiedMinCount") != null && theConstraint.get("qualifiedMaxCount") != null ?
+              SHACL.QUALIFIED_MIN_COUNT_CONSTRAINT_COMPONENT.stringValue() :
+              (theConstraint.get("qualifiedMinCount") != null ?
+                      SHACL.QUALIFIED_MIN_COUNT_CONSTRAINT_COMPONENT.stringValue() :
+                      SHACL.QUALIFIED_MAX_COUNT_CONSTRAINT_COMPONENT.stringValue()));
+
+      addQueriesForTrigger(vc, new ArrayList<String>(Arrays.asList(focusLabel)),
+              "QualifiedMinMaxCount", whereClause, constraintType,
+              buildArgArray(constraintType,
+                      Arrays.asList(paramSetId, focusLabel,
+                              (theConstraint.get("qualifiedMinCount") != null ? " toInteger(params.qualifiedMinCount) <= " : ""),
+                              propOrRel, qualifiedClassLabel,
+                              (theConstraint.get("qualifiedMaxCount") != null ? " <= toInteger(params.qualifiedMaxCount) " : ""),
+                              focusLabel, (String) theConstraint.get("propShapeUid"),
+                              constraintSHACLType, propOrRel, qualifiedClassLabel, propOrRel, severity, customMsg),
+                      Arrays.asList(paramSetId,
+                              (theConstraint.get("qualifiedMinCount") != null ? " toInteger(params.qualifiedMinCount) <= " : ""),
+                              propOrRel, qualifiedClassLabel,
+                              (theConstraint.get("qualifiedMaxCount") != null ? " <= toInteger(params.qualifiedMaxCount) " : ""),
+                              (String) theConstraint.get("propShapeUid"),
+                              constraintSHACLType, propOrRel, qualifiedClassLabel, propOrRel, severity, customMsg)));
+
+      //ADD constraint to the list
+      if (theConstraint.get("qualifiedMaxCount") != null) {
+        vc.addConstraintToList(new ConstraintComponent(getTargetForList(constraintType, focusLabel, whereClause), propOrRel,
+                printConstraintType(SHACL.QUALIFIED_MAX_COUNT), theConstraint.get("qualifiedMaxCount")));
+      }
+      if (theConstraint.get("qualifiedMinCount") != null) {
+        vc.addConstraintToList(new ConstraintComponent(getTargetForList(constraintType, focusLabel, whereClause), propOrRel,
+                printConstraintType(SHACL.QUALIFIED_MIN_COUNT), theConstraint.get("qualifiedMinCount")));
+      }
+
+    }
+
   }
 
   private void validateWhereClause(String whereClause)  {
@@ -1066,6 +1115,15 @@ public class SHACLValidator {
                   : null);
           record.put("maxStrLen",
               next.hasBinding("maxStrLen") ? ((Literal) next.getValue("maxStrLen")).intValue()
+                  : null);
+          record.put("qualifiedClass",
+              next.hasBinding("qualifiedClass") ? next.getValue("qualifiedClass").stringValue()
+                  : null);
+          record.put("qualifiedMinCount",
+              next.hasBinding("qualifiedMinCount") ? ((Literal) next.getValue("qualifiedMinCount")).intValue()
+                  : null);
+          record.put("qualifiedMaxCount",
+              next.hasBinding("qualifiedMaxCount") ? ((Literal) next.getValue("qualifiedMaxCount")).intValue()
                   : null);
           Value value = next.getValue("ps"); //if  this is null throw exception (?)
           if (value instanceof BNode) {
@@ -1525,6 +1583,15 @@ public class SHACLValidator {
                 "'%s' as propertyShape, '%s' as offendingValue, "
                 + "'" + (gc !=null && gc.getHandleVocabUris() != GRAPHCONF_VOC_URI_IGNORE ? RDF.TYPE : "type") + "' as propertyName, " + severityFragment
                 + " 'type %s: %s' as message , " + customMsgFragment);
+        break;
+      case "QualifiedMinMaxCount":
+        query = getQuery((constraintType == CLASS_BASED_CONSTRAINT ? CYPHER_WITH_PARAMS_MATCH_WHERE : CYPHER_WITH_PARAMS_MATCH_ALL_WHERE),
+                tx, (constraintType == QUERY_BASED_CONSTRAINT ? customWhere + " and " : ""),
+                "NOT %s size([(focus)-[:`%s`]->(x) WHERE x:`%s` | x]) %s RETURN "
+                + nodeIdFragment + nodeTypeFragment + shapeIdFragment
+                + "'%s' as propertyShape, 'qualified cardinality (' + coalesce(size([(focus)-[:`%s`]->(x) WHERE x:`%s` | x]),0) + ') is outside the defined min-max limits' as message, "
+                + propertyNameFragment + severityFragment
+                + "null as offendingValue , " + customMsgFragment);
         break;
     }
 

--- a/src/test/java/n10s/validation/SHACLValidationProceduresTest.java
+++ b/src/test/java/n10s/validation/SHACLValidationProceduresTest.java
@@ -2015,6 +2015,176 @@ public class SHACLValidationProceduresTest {
     }
   }
 
+  // ─── sh:qualifiedValueShape tests (LPG / non-RDF mode) ───────────────────────
+
+  /** qualifiedMinCount only: Person must have at least 1 KNOWS->Employee. */
+  @Test
+  public void testQualifiedValueShapeMinCountOnly() throws Exception {
+    try (Session session = driver.session()) {
+      assertFalse(session.run("MATCH (n) RETURN n").hasNext());
+
+      // alice has 1 KNOWS->Employee → valid
+      // bob has 0 KNOWS->Employee → violation
+      // carol has 1 KNOWS->Employee and 1 KNOWS->Contractor → valid
+      // dave has 0 KNOWS->Employee → violation
+      session.run(
+          "CREATE (alice:Person {name:'Alice'})-[:KNOWS]->(:Employee {name:'Eve'}) " +
+          "CREATE (bob:Person {name:'Bob'}) " +
+          "CREATE (carol:Person {name:'Carol'})-[:KNOWS]->(:Employee {name:'Ed'}) " +
+          "CREATE (carol)-[:KNOWS]->(:Contractor {name:'Fred'}) " +
+          "CREATE (dave:Person {name:'Dave'}) ");
+
+      String shacl =
+          "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+          "@prefix neo4j: <neo4j://graph.schema#> .\n" +
+          "neo4j:PersonShape a sh:NodeShape ;\n" +
+          "  sh:targetClass neo4j:Person ;\n" +
+          "  sh:property [\n" +
+          "    sh:path neo4j:KNOWS ;\n" +
+          "    sh:qualifiedValueShape [ sh:class neo4j:Employee ] ;\n" +
+          "    sh:qualifiedMinCount 1 ;\n" +
+          "  ] .\n";
+
+      session.run("CALL n10s.validation.shacl.import.inline('" + shacl + "', 'Turtle')");
+
+      Result result = session.run("CALL n10s.validation.shacl.validate()");
+
+      int violationCount = 0;
+      while (result.hasNext()) {
+        Record rec = result.next();
+        assertEquals(SHACL.QUALIFIED_MIN_COUNT_CONSTRAINT_COMPONENT.stringValue(),
+                rec.get("propertyShape").asString());
+        assertTrue(rec.get("resultMessage").asString().contains("qualified cardinality"));
+        violationCount++;
+      }
+      // bob and dave have 0 KNOWS->Employee
+      assertEquals(2, violationCount);
+    }
+  }
+
+  /** qualifiedMaxCount only: Person must have at most 1 KNOWS->Employee. */
+  @Test
+  public void testQualifiedValueShapeMaxCountOnly() throws Exception {
+    try (Session session = driver.session()) {
+      assertFalse(session.run("MATCH (n) RETURN n").hasNext());
+
+      // alice: 1 KNOWS->Employee → valid
+      // bob: 2 KNOWS->Employee → violation
+      session.run(
+          "CREATE (alice:Person {name:'Alice'})-[:KNOWS]->(:Employee {name:'Eve'}) " +
+          "CREATE (bob:Person {name:'Bob'}) " +
+          "CREATE (e1:Employee {name:'E1'}), (e2:Employee {name:'E2'}) " +
+          "WITH bob, e1, e2 MATCH (bob) MERGE (bob)-[:KNOWS]->(e1) MERGE (bob)-[:KNOWS]->(e2)");
+
+      String shacl =
+          "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+          "@prefix neo4j: <neo4j://graph.schema#> .\n" +
+          "neo4j:PersonShape a sh:NodeShape ;\n" +
+          "  sh:targetClass neo4j:Person ;\n" +
+          "  sh:property [\n" +
+          "    sh:path neo4j:KNOWS ;\n" +
+          "    sh:qualifiedValueShape [ sh:class neo4j:Employee ] ;\n" +
+          "    sh:qualifiedMaxCount 1 ;\n" +
+          "  ] .\n";
+
+      session.run("CALL n10s.validation.shacl.import.inline('" + shacl + "', 'Turtle')");
+
+      Result result = session.run("CALL n10s.validation.shacl.validate()");
+
+      int violationCount = 0;
+      while (result.hasNext()) {
+        Record rec = result.next();
+        assertEquals(SHACL.QUALIFIED_MAX_COUNT_CONSTRAINT_COMPONENT.stringValue(),
+                rec.get("propertyShape").asString());
+        violationCount++;
+      }
+      assertEquals(1, violationCount);
+    }
+  }
+
+  /** qualifiedMinCount + qualifiedMaxCount: Person must KNOWS between 1 and 2 Employees. */
+  @Test
+  public void testQualifiedValueShapeMinAndMaxCount() throws Exception {
+    try (Session session = driver.session()) {
+      assertFalse(session.run("MATCH (n) RETURN n").hasNext());
+
+      // alice: 0 Employee → violation (below min)
+      // bob: 1 Employee → valid
+      // carol: 3 Employees → violation (above max)
+      session.run(
+          "CREATE (alice:Person {name:'Alice'}) " +
+          "CREATE (bob:Person {name:'Bob'})-[:KNOWS]->(:Employee {name:'E1'}) " +
+          "CREATE (carol:Person {name:'Carol'}) " +
+          "CREATE (e2:Employee {name:'E2'}), (e3:Employee {name:'E3'}), (e4:Employee {name:'E4'}) " +
+          "WITH carol, e2, e3, e4 MATCH (carol) " +
+          "  MERGE (carol)-[:KNOWS]->(e2) MERGE (carol)-[:KNOWS]->(e3) MERGE (carol)-[:KNOWS]->(e4)");
+
+      String shacl =
+          "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+          "@prefix neo4j: <neo4j://graph.schema#> .\n" +
+          "neo4j:PersonShape a sh:NodeShape ;\n" +
+          "  sh:targetClass neo4j:Person ;\n" +
+          "  sh:property [\n" +
+          "    sh:path neo4j:KNOWS ;\n" +
+          "    sh:qualifiedValueShape [ sh:class neo4j:Employee ] ;\n" +
+          "    sh:qualifiedMinCount 1 ;\n" +
+          "    sh:qualifiedMaxCount 2 ;\n" +
+          "  ] .\n";
+
+      session.run("CALL n10s.validation.shacl.import.inline('" + shacl + "', 'Turtle')");
+
+      Result result = session.run("CALL n10s.validation.shacl.validate()");
+
+      int violationCount = 0;
+      while (result.hasNext()) {
+        Record rec = result.next();
+        // both min and max specified → component is QualifiedMinCount
+        assertEquals(SHACL.QUALIFIED_MIN_COUNT_CONSTRAINT_COMPONENT.stringValue(),
+                rec.get("propertyShape").asString());
+        violationCount++;
+      }
+      assertEquals(2, violationCount);
+    }
+  }
+
+  /**
+   * Verify that qualified cardinality counts only rels to nodes with the required class label,
+   * not all rels along the path. Person KNOWS 4 nodes but only 1 is an Employee → with qMin=1
+   * qMax=3 this should produce no violations.
+   */
+  @Test
+  public void testQualifiedValueShapeCountsOnlyMatchingClass() throws Exception {
+    try (Session session = driver.session()) {
+      assertFalse(session.run("MATCH (n) RETURN n").hasNext());
+
+      // focus has 4 KNOWS rels, 1 to Employee → count=1, within [1,3] → valid
+      session.run(
+          "CREATE (p:Person {name:'Alice'}) " +
+          "CREATE (e:Employee {name:'Bob'}), (c1:Customer {name:'C1'}), " +
+          "       (c2:Customer {name:'C2'}), (c3:Customer {name:'C3'}) " +
+          "WITH p, e, c1, c2, c3 MATCH (p) " +
+          "  MERGE (p)-[:KNOWS]->(e) MERGE (p)-[:KNOWS]->(c1) " +
+          "  MERGE (p)-[:KNOWS]->(c2) MERGE (p)-[:KNOWS]->(c3)");
+
+      String shacl =
+          "@prefix sh: <http://www.w3.org/ns/shacl#> .\n" +
+          "@prefix neo4j: <neo4j://graph.schema#> .\n" +
+          "neo4j:PersonShape a sh:NodeShape ;\n" +
+          "  sh:targetClass neo4j:Person ;\n" +
+          "  sh:property [\n" +
+          "    sh:path neo4j:KNOWS ;\n" +
+          "    sh:qualifiedValueShape [ sh:class neo4j:Employee ] ;\n" +
+          "    sh:qualifiedMinCount 1 ;\n" +
+          "    sh:qualifiedMaxCount 3 ;\n" +
+          "  ] .\n";
+
+      session.run("CALL n10s.validation.shacl.import.inline('" + shacl + "', 'Turtle')");
+
+      // no violations expected
+      assertFalse(session.run("CALL n10s.validation.shacl.validate()").hasNext());
+    }
+  }
+
   private boolean contains(Set<ValidationResult> set, ValidationResult res) {
     boolean contained = false;
     for (ValidationResult vr : set) {


### PR DESCRIPTION
## Summary

Adds support for the `sh:qualifiedValueShape` constraint in the SHACL validator, allowing cardinality checks scoped to a specific target class:

```turtle
ex:PersonShape a sh:NodeShape ;
  sh:targetClass ex:Person ;
  sh:property [
    sh:path ex:knows ;
    sh:qualifiedValueShape [ sh:class ex:Employee ] ;
    sh:qualifiedMinCount 1 ;
    sh:qualifiedMaxCount 3 ;
  ] .
```

This validates that each `:Person` node has between 1 and 3 `knows` relationships pointing to `:Employee` nodes (other relationship targets are ignored by the count).

## Changes

- **`SHACLValidator.java`**: Extended SPARQL extraction query to pull `sh:qualifiedValueShape/sh:class`, `sh:qualifiedMinCount`, and `sh:qualifiedMaxCount`; added `"QualifiedMinMaxCount"` Cypher generation using list-comprehension pattern `[(focus)-[:rel]->(x) WHERE x:Label | x]`
- **`SHACLValidationProceduresTest.java`**: 4 new tests — min-only, max-only, both bounds, and class-filtering correctness
- **`docs/modules/ROOT/pages/validation.adoc`**: New `sh:qualifiedValueShape` section with full Turtle + Cypher example

## Test plan

- [x] `testQualifiedValueShapeMinCountOnly` — 2 violations detected
- [x] `testQualifiedValueShapeMaxCountOnly` — 1 violation detected
- [x] `testQualifiedValueShapeMinAndMaxCount` — 2 violations detected
- [x] `testQualifiedValueShapeCountsOnlyMatchingClass` — 0 violations (non-matching class not counted)
- [x] All 67 tests pass

Fixes #269