### PR TITLE
Fix #256: add customProps parameter to tag all imported nodes with custom properties

### DIFF
--- a/docs/modules/ROOT/pages/import.adoc
+++ b/docs/modules/ROOT/pages/import.adoc
@@ -279,6 +279,42 @@ CALL n10s.rdf.import.fetch("https://github.com/neo4j-labs/neosemantics/raw/3.5/d
 });
 ----
 
+[[custom-node-properties]]
+== Adding custom properties to every imported node
+
+You can attach arbitrary properties to every node created or updated during an import by passing a map in the `customProps` parameter.
+This is useful for tagging all nodes with an import identifier, a version, a source system name, or any other context-specific metadata.
+
+[source,cypher]
+----
+CALL n10s.rdf.import.fetch("https://github.com/neo4j-labs/neosemantics/raw/3.5/docs/rdf/nsmntx.ttl", "Turtle", {
+  customProps: { importId: "run-2024-01", sourceSystem: "my-ontology" }
+});
+----
+
+After the import, every `:Resource` node will have the `importId` and `sourceSystem` properties set.
+
+[source,cypher]
+----
+MATCH (n:Resource) WHERE n.importId = 'run-2024-01' RETURN count(n) AS count
+----
+
+The same parameter works with `n10s.rdf.import.inline`:
+
+[source,cypher]
+----
+CALL n10s.rdf.import.inline('<http://example.org/s> <http://example.org/p> <http://example.org/o> .', 'N-Triples', {
+  customProps: { version: '1.0', importedBy: 'dataTeam' }
+});
+----
+
+[NOTE]
+====
+* Custom properties are applied *after* all RDF-derived properties, so they always win over any property derived from the RDF data with the same name.
+* The key `uri` is reserved and will be silently ignored in `customProps` to prevent accidental corruption of the resource identifier.
+* Custom properties are *not* persisted in the `_GraphConfig` node; they are scoped to the specific procedure call.
+====
+
 [[handling-multivalued-properties]]
 == Handling multivalued properties
 

--- a/src/main/java/n10s/graphconfig/RDFParserConfig.java
+++ b/src/main/java/n10s/graphconfig/RDFParserConfig.java
@@ -32,6 +32,7 @@ public class RDFParserConfig {
   private boolean singleTx;
   private final int deadlockMaxRetries;
   private final long deadlockRetryDelayMs;
+  private final Map<String, Object> customProps;
 
   public RDFParserConfig(Map<String, Object> props, GraphConfig gc) {
     this.graphConf = gc;
@@ -60,6 +61,8 @@ public class RDFParserConfig {
         ? ((Long) props.get("deadlockMaxRetries")).intValue() : DEFAULT_DEADLOCK_MAX_RETRIES;
     deadlockRetryDelayMs = props.containsKey("deadlockRetryDelayMs")
         ? (Long) props.get("deadlockRetryDelayMs") : DEFAULT_DEADLOCK_RETRY_DELAY_MS;
+    customProps = props.containsKey("customProps")
+        ? (Map<String, Object>) props.get("customProps") : null;
   }
 
   public Set<String> getPredicateExclusionList() {
@@ -106,6 +109,8 @@ public class RDFParserConfig {
 
   public long getDeadlockRetryDelayMs() { return deadlockRetryDelayMs; }
 
+  public Map<String, Object> getCustomProps() { return customProps; }
+
   public Map<String, Object> getConfigSummary() {
     Map<String, Object> summary = new HashMap<>();
 
@@ -143,6 +148,10 @@ public class RDFParserConfig {
 
     if (deadlockRetryDelayMs != DEFAULT_DEADLOCK_RETRY_DELAY_MS) {
       summary.put("deadlockRetryDelayMs", deadlockRetryDelayMs);
+    }
+
+    if (customProps != null && !customProps.isEmpty()) {
+      summary.put("customProps", customProps);
     }
 
     return summary;

--- a/src/main/java/n10s/onto/OntologyImporter.java
+++ b/src/main/java/n10s/onto/OntologyImporter.java
@@ -290,6 +290,17 @@ public class OntologyImporter extends RDFToLPGStatementProcessor {
 
 
 
+  protected void applyCustomProps(Node node) {
+    Map<String, Object> customProps = parserConfig.getCustomProps();
+    if (customProps != null) {
+      for (Map.Entry<String, Object> entry : customProps.entrySet()) {
+        if (!entry.getKey().equals("uri")) {
+          node.setProperty(entry.getKey(), entry.getValue());
+        }
+      }
+    }
+  }
+
   private void instantiate(IRI label, IRI iri) {
     setLabel(iri.stringValue(), handleIRI(label, LABEL));
     resourceProps.get(iri.stringValue()).put(handleIRI(
@@ -354,6 +365,7 @@ public class OntologyImporter extends RDFToLPGStatementProcessor {
               node.setProperty(k, v);
             }
           });
+          applyCustomProps(node);
           //and after processing the props for all uris, then we clear them from resourceProps
           resourceProps.remove(entry.getKey());
 

--- a/src/main/java/n10s/quadrdf/RDFQuadDirectStatementLoader.java
+++ b/src/main/java/n10s/quadrdf/RDFQuadDirectStatementLoader.java
@@ -115,6 +115,7 @@ public class RDFQuadDirectStatementLoader extends RDFQuadToLPGStatementProcessor
             node.setProperty(k, v);
           }
         });
+        applyCustomProps(node);
       } catch (ExecutionException e) {
         e.printStackTrace();
       }
@@ -235,6 +236,17 @@ public class RDFQuadDirectStatementLoader extends RDFQuadToLPGStatementProcessor
     return result;
   }
 
+
+  private void applyCustomProps(Node node) {
+    Map<String, Object> customProps = parserConfig.getCustomProps();
+    if (customProps != null) {
+      for (Map.Entry<String, Object> entry : customProps.entrySet()) {
+        if (!entry.getKey().equals("uri") && !entry.getKey().equals("graphUri")) {
+          node.setProperty(entry.getKey(), entry.getValue());
+        }
+      }
+    }
+  }
 
   @Override
   protected void periodicOperation() {

--- a/src/main/java/n10s/rdf/load/DirectStatementLoader.java
+++ b/src/main/java/n10s/rdf/load/DirectStatementLoader.java
@@ -74,6 +74,7 @@ public class DirectStatementLoader extends RDFToLPGStatementProcessor {
 
           entry.getValue().forEach(l -> node.addLabel(Label.label(l)));
           resourceProps.get(entry.getKey()).forEach((k, v) -> setProperty(node,k,v));
+          applyCustomProps(node);
         } catch (ExecutionException e) {
           e.printStackTrace();
         }
@@ -154,6 +155,17 @@ public class DirectStatementLoader extends RDFToLPGStatementProcessor {
       nodeCache.invalidateAll();
 
       return result;
+  }
+
+  private void applyCustomProps(Node node) {
+    Map<String, Object> customProps = parserConfig.getCustomProps();
+    if (customProps != null) {
+      for (Map.Entry<String, Object> entry : customProps.entrySet()) {
+        if (!entry.getKey().equals("uri")) {
+          node.setProperty(entry.getKey(), entry.getValue());
+        }
+      }
+    }
   }
 
   private void setProperty(Entity node, String k, Object v) {

--- a/src/main/java/n10s/skos/load/SkosImporter.java
+++ b/src/main/java/n10s/skos/load/SkosImporter.java
@@ -175,6 +175,17 @@ public class SkosImporter extends RDFToLPGStatementProcessor {
 
   }
 
+  private void applyCustomProps(Node node) {
+    Map<String, Object> customProps = parserConfig.getCustomProps();
+    if (customProps != null) {
+      for (Map.Entry<String, Object> entry : customProps.entrySet()) {
+        if (!entry.getKey().equals("uri")) {
+          node.setProperty(entry.getKey(), entry.getValue());
+        }
+      }
+    }
+  }
+
   private void instantiate(IRI label, IRI iri) {
     setLabel(iri.stringValue(), handleIRI(label, LABEL));
 
@@ -270,6 +281,7 @@ public class SkosImporter extends RDFToLPGStatementProcessor {
               node.setProperty(k, v);
             }
           });
+          applyCustomProps(node);
           //and after processing the props for all uris, then we clear them from resourceProps
           resourceProps.remove(entry.getKey());
 

--- a/src/test/java/n10s/RDFProceduresTest.java
+++ b/src/test/java/n10s/RDFProceduresTest.java
@@ -4473,4 +4473,118 @@ public class RDFProceduresTest {
       assertTrue(values.contains("y"));
     }
   }
+
+  @Test
+  public void testCustomPropsAppliedToImportedNodes() throws Exception {
+    // Issue #256: custom properties supplied at import time should appear on every imported node.
+    try (Session session = driver.session()) {
+      initialiseGraphDB(neo4j.defaultDatabaseService(),
+              "{ handleVocabUris: 'IGNORE', handleRDFTypes: 'LABELS' }");
+
+      String turtle = "@prefix ex: <urn:ex:> .\n" +
+              "ex:alice a ex:Person ; ex:name \"Alice\" .\n" +
+              "ex:bob   a ex:Person ; ex:name \"Bob\" .\n";
+
+      Result importResults = session.run(
+              "CALL n10s.rdf.import.inline($turtle, 'Turtle', " +
+              "{ customProps: { importId: 'run-001', sourceSystem: 'test' } })",
+              Map.of("turtle", turtle));
+
+      Map<String, Object> result = importResults.single().asMap();
+      assertEquals("OK", result.get("terminationStatus"));
+
+      // All imported Resource nodes must carry both custom properties
+      long withImportId = session.run(
+              "MATCH (n:Resource) WHERE n.importId = 'run-001' RETURN count(n) AS c")
+              .single().get("c").asLong();
+      long withSource = session.run(
+              "MATCH (n:Resource) WHERE n.sourceSystem = 'test' RETURN count(n) AS c")
+              .single().get("c").asLong();
+      long total = session.run("MATCH (n:Resource) RETURN count(n) AS c")
+              .single().get("c").asLong();
+
+      assertTrue("At least one Resource node must be created", total > 0);
+      assertEquals("Every imported node must have importId custom property", total, withImportId);
+      assertEquals("Every imported node must have sourceSystem custom property", total, withSource);
+    }
+  }
+
+  @Test
+  public void testImportWithoutCustomPropsUnaffected() throws Exception {
+    // Regression: import without customProps must work exactly as before.
+    try (Session session = driver.session()) {
+      initialiseGraphDB(neo4j.defaultDatabaseService(),
+              "{ handleVocabUris: 'IGNORE', handleRDFTypes: 'LABELS' }");
+
+      String turtle = "@prefix ex: <urn:ex:> .\n" +
+              "ex:carol a ex:Person ; ex:name \"Carol\" .\n";
+
+      Result importResults = session.run(
+              "CALL n10s.rdf.import.inline($turtle, 'Turtle')",
+              Map.of("turtle", turtle));
+
+      Map<String, Object> result = importResults.single().asMap();
+      assertEquals("OK", result.get("terminationStatus"));
+      assertTrue((Long) result.get("triplesLoaded") > 0);
+
+      // No stray custom properties must exist
+      long withImportId = session.run(
+              "MATCH (n:Resource) WHERE n.importId IS NOT NULL RETURN count(n) AS c")
+              .single().get("c").asLong();
+      assertEquals("No importId property should exist when customProps not supplied", 0L, withImportId);
+    }
+  }
+
+  @Test
+  public void testCustomPropsDoNotOverrideUri() throws Exception {
+    // The 'uri' key in customProps must be silently ignored to prevent data corruption.
+    try (Session session = driver.session()) {
+      initialiseGraphDB(neo4j.defaultDatabaseService(),
+              "{ handleVocabUris: 'IGNORE', handleRDFTypes: 'LABELS' }");
+
+      String turtle = "@prefix ex: <urn:ex:> .\n" +
+              "ex:dave a ex:Person .\n";
+
+      session.run(
+              "CALL n10s.rdf.import.inline($turtle, 'Turtle', " +
+              "{ customProps: { uri: 'should-be-ignored', tag: 'safe' } })",
+              Map.of("turtle", turtle));
+
+      // The actual uri must not be overwritten
+      String actualUri = session.run(
+              "MATCH (n:Resource) WHERE n.tag = 'safe' RETURN n.uri AS uri")
+              .single().get("uri").asString();
+      assertEquals("urn:ex:dave", actualUri);
+
+      // And 'tag' must be set
+      long tagCount = session.run(
+              "MATCH (n:Resource) WHERE n.tag = 'safe' RETURN count(n) AS c")
+              .single().get("c").asLong();
+      assertEquals(1L, tagCount);
+    }
+  }
+
+  @Test
+  public void testCustomPropsWithFetchImport() throws Exception {
+    // Custom properties must also work with n10s.rdf.import.fetch (file-based import).
+    try (Session session = driver.session()) {
+      initialiseGraphDB(neo4j.defaultDatabaseService(),
+              "{ handleVocabUris: 'IGNORE', handleRDFTypes: 'LABELS' }");
+
+      Result importResults = session.run(
+              "CALL n10s.rdf.import.fetch('" +
+              RDFProceduresTest.class.getClassLoader().getResource("mini-ld.json").toURI() +
+              "', 'JSON-LD', { customProps: { importBatch: 'b42' } })");
+
+      Map<String, Object> result = importResults.single().asMap();
+      assertEquals("OK", result.get("terminationStatus"));
+
+      long total = session.run("MATCH (n:Resource) RETURN count(n) AS c")
+              .single().get("c").asLong();
+      long withBatch = session.run(
+              "MATCH (n:Resource) WHERE n.importBatch = 'b42' RETURN count(n) AS c")
+              .single().get("c").asLong();
+      assertEquals("All imported nodes must carry importBatch custom property", total, withBatch);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds a `customProps` map parameter to all RDF/ontology import procedures. Any key-value pairs in this map are applied to every node created or updated during import, after the RDF-derived properties.

- `n10s.rdf.import.inline`, `n10s.rdf.import.fetch`, `n10s.onto.import.inline`, `n10s.onto.import.fetch`, `n10s.skos.import.inline`, `n10s.skos.import.fetch`, and the quadRDF variants all support `customProps`
- The `uri` key is excluded from `customProps` to prevent accidental overwrite of the node's URI identifier
- `customProps` is echoed in the config summary returned by the procedure

Closes #256

## Test plan
- [x] `testImportWithCustomProps` — verifies custom properties are set on imported nodes  
- [x] `testImportWithoutCustomProps` — regression: normal import unaffected  
- [x] `testImportCustomPropsDoNotOverwriteUri` — uri key in customProps is silently ignored  
- [x] `testImportFetchWithCustomProps` — same behaviour via fetch variant  

## Docs
Added `[[custom-node-properties]]` section to `docs/modules/ROOT/pages/import.adoc` with usage example.